### PR TITLE
rspirv: Update to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ winapi = "0.3.7"
 bitflags = "1.1.0"
 
 [dev-dependencies]
-rspirv = "0.5.4"
+rspirv = "0.6.0"
 
 [features]
 default = ["winapi/wtypes", "winapi/oleauto"]

--- a/examples/include.rs
+++ b/examples/include.rs
@@ -1,6 +1,6 @@
 use hassle_rs::*;
 use rspirv::binary::Disassemble;
-use rspirv::mr::load_bytes;
+use rspirv::dr::load_bytes;
 
 fn main() {
     let source = include_str!("include.hlsl");

--- a/examples/spirv.rs
+++ b/examples/spirv.rs
@@ -1,6 +1,6 @@
 use hassle_rs::*;
 use rspirv::binary::Disassemble;
-use rspirv::mr::load_bytes;
+use rspirv::dr::load_bytes;
 
 fn main() {
     let source = include_str!("copy.hlsl");


### PR DESCRIPTION
Fixes the following on 0.5.4:

    error[E0308]: mismatched types
       --> /home/marijn/.cargo/registry/src/github.com-1ecc6299db9ec823/rspirv-0.5.4/mr/constructs.rs:190:22
        |
    190 |             version: (spirv::MAJOR_VERSION << 16) | (spirv::MINOR_VERSION << 8),
        |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `u8`

Also fix line endings from CRLF -> LF in examples/include.rs.