### PR TITLE
GitHub: Add dependabot configuration for update notifications

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: all


### PR DESCRIPTION
Use dependabot to notify us about dependency updates.
