### PR TITLE
Fix error source; free leaked allocations; fix refcounting; BSTR is wide, not UTF-8; convert return_hr to expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,10 @@ widestring = "0.4.2"
 thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["wtypes", "oleauto"] }
+winapi = { version = "0.3.9", features = ["wtypes", "oleauto", "combaseapi"] }
+
+[target.'cfg(not(windows))'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 rspirv = "0.6.0"

--- a/examples/intellisense-tu.rs
+++ b/examples/intellisense-tu.rs
@@ -32,6 +32,7 @@ fn main() {
 
         let name = cursor.get_display_name().unwrap();
         println!("Name {:?}", name);
+        assert_eq!(name, "copy.hlsl");
 
         let cursor_kind = cursor.get_kind().unwrap();
         println!("CursorKind {:?}", cursor_kind);
@@ -41,6 +42,19 @@ fn main() {
     }
 
     let child_cursors = cursor.get_all_children().unwrap();
+
+    assert_eq!(
+        child_cursors[0].get_display_name(),
+        Ok("g_input".to_owned())
+    );
+    assert_eq!(
+        child_cursors[1].get_display_name(),
+        Ok("g_output".to_owned())
+    );
+    assert_eq!(
+        child_cursors[2].get_display_name(),
+        Ok("copyCs(uint3)".to_owned())
+    );
 
     for child_cursor in child_cursors {
         let range = child_cursor.get_extent().unwrap();

--- a/src/intellisense/wrapper.rs
+++ b/src/intellisense/wrapper.rs
@@ -18,20 +18,20 @@ impl DxcIntellisense {
     pub fn get_default_editing_tu_options(&self) -> Result<DxcTranslationUnitFlags, HRESULT> {
         let mut options: DxcTranslationUnitFlags = DxcTranslationUnitFlags::NONE;
         unsafe {
-            return_hr!(
+            check_hr!(
                 self.inner.get_default_editing_tu_options(&mut options),
                 options
-            );
+            )
         }
     }
 
     pub fn create_index(&self) -> Result<DxcIndex, HRESULT> {
         let mut index: ComPtr<IDxcIndex> = ComPtr::new();
         unsafe {
-            return_hr!(
+            check_hr!(
                 self.inner.create_index(index.as_mut_ptr()),
                 DxcIndex::new(index)
-            );
+            )
         }
     }
 
@@ -45,7 +45,7 @@ impl DxcIntellisense {
 
         let mut file: ComPtr<IDxcUnsavedFile> = ComPtr::new();
         unsafe {
-            return_hr!(
+            check_hr!(
                 self.inner.create_unsaved_file(
                     c_file_name.as_ptr(),
                     c_contents.as_ptr(),
@@ -53,7 +53,7 @@ impl DxcIntellisense {
                     file.as_mut_ptr()
                 ),
                 DxcUnsavedFile::new(file)
-            );
+            )
         }
     }
 }
@@ -97,7 +97,7 @@ impl DxcIndex {
             }
 
             let mut tu: ComPtr<IDxcTranslationUnit> = ComPtr::new();
-            return_hr!(
+            check_hr!(
                 self.inner.parse_translation_unit(
                     c_source_filename.as_ptr() as *const u8,
                     cliargs.as_ptr(),
@@ -108,7 +108,7 @@ impl DxcIndex {
                     tu.as_mut_ptr()
                 ),
                 DxcTranslationUnit::new(tu)
-            );
+            )
         }
     }
 }
@@ -121,9 +121,7 @@ pub struct DxcUnsavedFile {
 impl DxcUnsavedFile {
     pub fn get_length(&self) -> Result<u32, HRESULT> {
         let mut length: u32 = 0;
-        unsafe {
-            return_hr!(self.inner.get_length(&mut length), length);
-        }
+        unsafe { check_hr!(self.inner.get_length(&mut length), length) }
     }
 
     fn new(inner: ComPtr<IDxcUnsavedFile>) -> Self {
@@ -144,20 +142,20 @@ impl DxcTranslationUnit {
     pub fn get_file(&self, name: &[u8]) -> Result<DxcFile, HRESULT> {
         let mut file: ComPtr<IDxcFile> = ComPtr::new();
         unsafe {
-            return_hr!(
+            check_hr!(
                 self.inner.get_file(name.as_ptr(), file.as_mut_ptr()),
                 DxcFile::new(file)
-            );
+            )
         }
     }
 
     pub fn get_cursor(&self) -> Result<DxcCursor, HRESULT> {
         let mut cursor: ComPtr<IDxcCursor> = ComPtr::new();
         unsafe {
-            return_hr!(
+            check_hr!(
                 self.inner.get_cursor(cursor.as_mut_ptr()),
                 DxcCursor::new(cursor)
-            );
+            )
         }
     }
 }
@@ -177,7 +175,7 @@ impl DxcCursor {
             let mut result: *mut *mut IDxcCursor = std::ptr::null_mut();
             let mut result_length: u32 = 0;
 
-            return_hr!(
+            check_hr!(
                 self.inner
                     .get_children(skip, max_count, &mut result_length, &mut result),
                 // get_children allocates a buffer to pass the result in.  Vec will
@@ -190,7 +188,7 @@ impl DxcCursor {
                         DxcCursor::new(childcursor)
                     })
                     .collect::<Vec<_>>()
-            );
+            )
         }
     }
 
@@ -211,135 +209,135 @@ impl DxcCursor {
     pub fn get_extent(&self) -> Result<DxcSourceRange, HRESULT> {
         unsafe {
             let mut range: ComPtr<IDxcSourceRange> = ComPtr::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_extent(range.as_mut_ptr()),
                 DxcSourceRange::new(range)
-            );
+            )
         }
     }
 
     pub fn get_location(&self) -> Result<DxcSourceLocation, HRESULT> {
         unsafe {
             let mut location: ComPtr<IDxcSourceLocation> = ComPtr::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_location(location.as_mut_ptr()),
                 DxcSourceLocation::new(location)
-            );
+            )
         }
     }
 
     pub fn get_display_name(&self) -> Result<String, HRESULT> {
         unsafe {
             let mut name: BSTR = std::ptr::null_mut();
-            return_hr!(
+            check_hr!(
                 self.inner.get_display_name(&mut name),
                 crate::utils::from_bstr(name)
-            );
+            )
         }
     }
 
     pub fn get_formatted_name(&self, formatting: DxcCursorFormatting) -> Result<String, HRESULT> {
         unsafe {
             let mut name: BSTR = std::ptr::null_mut();
-            return_hr!(
+            check_hr!(
                 self.inner.get_formatted_name(formatting, &mut name),
                 crate::utils::from_bstr(name)
-            );
+            )
         }
     }
 
     pub fn get_qualified_name(&self, include_template_args: bool) -> Result<String, HRESULT> {
         unsafe {
             let mut name: BSTR = std::ptr::null_mut();
-            return_hr!(
+            check_hr!(
                 self.inner
                     .get_qualified_name(include_template_args, &mut name),
                 crate::utils::from_bstr(name)
-            );
+            )
         }
     }
 
     pub fn get_kind(&self) -> Result<DxcCursorKind, HRESULT> {
         unsafe {
             let mut cursor_kind: DxcCursorKind = DxcCursorKind::UNEXPOSED_DECL;
-            return_hr!(self.inner.get_kind(&mut cursor_kind), cursor_kind);
+            check_hr!(self.inner.get_kind(&mut cursor_kind), cursor_kind)
         }
     }
 
     pub fn get_kind_flags(&self) -> Result<DxcCursorKindFlags, HRESULT> {
         unsafe {
             let mut cursor_kind_flags: DxcCursorKindFlags = DxcCursorKindFlags::NONE;
-            return_hr!(
+            check_hr!(
                 self.inner.get_kind_flags(&mut cursor_kind_flags),
                 cursor_kind_flags
-            );
+            )
         }
     }
 
     pub fn get_semantic_parent(&self) -> Result<DxcCursor, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcCursor>::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_semantic_parent(inner.as_mut_ptr()),
                 DxcCursor::new(inner)
-            );
+            )
         }
     }
 
     pub fn get_lexical_parent(&self) -> Result<DxcCursor, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcCursor>::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_lexical_parent(inner.as_mut_ptr()),
                 DxcCursor::new(inner)
-            );
+            )
         }
     }
 
     pub fn get_cursor_type(&self) -> Result<DxcType, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcType>::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_cursor_type(inner.as_mut_ptr()),
                 DxcType::new(inner)
-            );
+            )
         }
     }
 
     pub fn get_num_arguments(&self) -> Result<i32, HRESULT> {
         unsafe {
             let mut result: i32 = 0;
-            return_hr!(self.inner.get_num_arguments(&mut result), result);
+            check_hr!(self.inner.get_num_arguments(&mut result), result)
         }
     }
 
     pub fn get_argument_at(&self, index: i32) -> Result<DxcCursor, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcCursor>::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_argument_at(index, inner.as_mut_ptr()),
                 DxcCursor::new(inner)
-            );
+            )
         }
     }
 
     pub fn get_referenced_cursor(&self) -> Result<DxcCursor, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcCursor>::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_referenced_cursor(inner.as_mut_ptr()),
                 DxcCursor::new(inner)
-            );
+            )
         }
     }
 
     pub fn get_definition_cursor(&self) -> Result<DxcCursor, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcCursor>::new();
-            return_hr!(
+            check_hr!(
                 self.inner.get_definition_cursor(inner.as_mut_ptr()),
                 DxcCursor::new(inner)
-            );
+            )
         }
     }
 
@@ -353,7 +351,7 @@ impl DxcCursor {
             let mut result: *mut *mut IDxcCursor = std::ptr::null_mut();
             let mut result_length: u32 = 0;
 
-            return_hr!(
+            check_hr!(
                 self.inner.find_references_in_file(
                     file.inner.as_ptr(),
                     skip,
@@ -371,52 +369,52 @@ impl DxcCursor {
                         DxcCursor::new(childcursor)
                     })
                     .collect::<Vec<_>>()
-            );
+            )
         }
     }
 
     pub fn get_spelling(&self) -> Result<String, HRESULT> {
         unsafe {
             let mut spelling: LPSTR = std::ptr::null_mut();
-            return_hr!(
+            check_hr!(
                 self.inner.get_spelling(&mut spelling),
                 crate::utils::from_lpstr(spelling)
-            );
+            )
         }
     }
 
     pub fn is_equal_to(&self, other: &DxcCursor) -> Result<bool, HRESULT> {
         unsafe {
             let mut result: bool = false;
-            return_hr!(
+            check_hr!(
                 self.inner.is_equal_to(other.inner.as_ptr(), &mut result),
                 result
-            );
+            )
         }
     }
 
     pub fn is_null(&mut self) -> Result<bool, HRESULT> {
         unsafe {
             let mut result: bool = false;
-            return_hr!(IDxcCursor::is_null(&self.inner, &mut result), result);
+            check_hr!(IDxcCursor::is_null(&self.inner, &mut result), result)
         }
     }
 
     pub fn is_definition(&self) -> Result<bool, HRESULT> {
         unsafe {
             let mut result: bool = false;
-            return_hr!(self.inner.is_definition(&mut result), result);
+            check_hr!(self.inner.is_definition(&mut result), result)
         }
     }
 
     pub fn get_snapped_child(&self, location: &DxcSourceLocation) -> Result<DxcCursor, HRESULT> {
         unsafe {
             let mut inner = ComPtr::<IDxcCursor>::new();
-            return_hr!(
+            check_hr!(
                 self.inner
                     .get_snapped_child(location.inner.as_ptr(), inner.as_mut_ptr()),
                 DxcCursor::new(inner)
-            );
+            )
         }
     }
 
@@ -447,10 +445,10 @@ impl DxcType {
     pub fn get_spelling(&self) -> Result<String, HRESULT> {
         unsafe {
             let mut spelling: LPSTR = std::ptr::null_mut();
-            return_hr!(
+            check_hr!(
                 self.inner.get_spelling(&mut spelling),
                 crate::utils::from_lpstr(spelling)
-            );
+            )
         }
     }
 }
@@ -482,13 +480,13 @@ impl DxcSourceRange {
         unsafe {
             let mut start_offset: u32 = 0;
             let mut end_offset: u32 = 0;
-            return_hr!(
+            check_hr!(
                 self.inner.get_offsets(&mut start_offset, &mut end_offset),
                 DxcSourceOffsets {
                     start_offset,
                     end_offset
                 }
-            );
+            )
         }
     }
 }
@@ -513,13 +511,13 @@ impl DxcFile {
 impl Dxc {
     pub fn create_intellisense(&self) -> Result<DxcIntellisense, HassleError> {
         let mut intellisense: ComPtr<IDxcIntelliSense> = ComPtr::new();
-        return_hr_wrapped!(
+        check_hr_wrapped!(
             self.get_dxc_create_instance()?(
                 &CLSID_DxcIntelliSense,
                 &IID_IDxcIntelliSense,
                 intellisense.as_mut_ptr(),
             ),
             DxcIntellisense::new(intellisense)
-        );
+        )
     }
 }

--- a/src/os.rs
+++ b/src/os.rs
@@ -6,6 +6,7 @@ mod os_defs {
     };
 
     pub use winapi::um::combaseapi::CoTaskMemFree;
+    pub use winapi::um::oleauto::SysFreeString;
 }
 
 #[cfg(not(windows))]
@@ -25,6 +26,12 @@ mod os_defs {
     pub unsafe fn CoTaskMemFree(p: *mut libc::c_void) {
         // https://github.com/microsoft/DirectXShaderCompiler/blob/a8d9780046cb64a1cea842fa6fc28a250e3e2c09/include/dxc/Support/WinAdapter.h#L46
         libc::free(p)
+    }
+
+    #[allow(non_snake_case)]
+    pub unsafe fn SysFreeString(p: BSTR) {
+        // https://github.com/microsoft/DirectXShaderCompiler/blob/a8d9780046cb64a1cea842fa6fc28a250e3e2c09/include/dxc/Support/WinAdapter.h#L48-L50
+        libc::free(p as _)
     }
 }
 

--- a/src/os.rs
+++ b/src/os.rs
@@ -4,6 +4,8 @@ mod os_defs {
         ntdef::{HRESULT, LPCSTR, LPCWSTR, LPSTR, LPWSTR, WCHAR},
         wtypes::BSTR,
     };
+
+    pub use winapi::um::combaseapi::CoTaskMemFree;
 }
 
 #[cfg(not(windows))]
@@ -18,6 +20,12 @@ mod os_defs {
     pub type BSTR = *mut OLECHAR;
     pub type LPBSTR = *mut BSTR;
     pub type HRESULT = i32;
+
+    #[allow(non_snake_case)]
+    pub unsafe fn CoTaskMemFree(p: *mut libc::c_void) {
+        // https://github.com/microsoft/DirectXShaderCompiler/blob/a8d9780046cb64a1cea842fa6fc28a250e3e2c09/include/dxc/Support/WinAdapter.h#L46
+        libc::free(p)
+    }
 }
 
 pub use os_defs::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
-use crate::os::{BSTR, HRESULT, LPSTR, LPWSTR, WCHAR};
+use crate::os::{SysFreeString, BSTR, HRESULT, LPSTR, LPWSTR, WCHAR};
 use crate::wrapper::*;
 use thiserror::Error;
 
 #[cfg(windows)]
-use winapi::um::oleauto::{SysFreeString, SysStringLen};
+use winapi::um::oleauto::SysStringLen;
 
 pub(crate) fn to_wide(msg: &str) -> Vec<WCHAR> {
     widestring::WideCString::from_str(msg).unwrap().into_vec()
@@ -33,7 +33,9 @@ pub(crate) fn from_bstr(string: BSTR) -> String {
     // TODO (Marijn): This does NOT cover embedded NULLs:
     // https://docs.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-sysstringlen#remarks
     // Fortunately BSTRs are only used in names currently, which _likely_ don't include NULL characters (like binary data)
-    from_lpstr(string as LPSTR)
+    let result = from_lpstr(string as LPSTR);
+    unsafe { SysFreeString(string) };
+    result
 }
 
 pub(crate) fn from_lpstr(string: LPSTR) -> String {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -69,9 +69,10 @@ pub enum HassleError {
     CompileError(String),
     #[error("Validation error: {0}")]
     ValidationError(String),
-    #[error("Error loading library {filename:?} / {inner:?}")]
+    #[error("Failed to load library {filename:?}: {inner:?}")]
     LoadLibraryError {
         filename: String,
+        #[source]
         inner: libloading::Error,
     },
     #[error("LibLoading error: {0:?}")]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -14,26 +14,26 @@ use std::ffi::c_void;
 use std::rc::Rc;
 
 #[macro_export]
-macro_rules! return_hr {
-    ($hr:expr, $v: expr) => {
+macro_rules! check_hr {
+    ($hr:expr, $v: expr) => {{
         let hr = $hr;
         if hr == 0 {
-            return Ok($v);
+            Ok($v)
         } else {
-            return Err(hr);
+            Err(hr)
         }
-    };
+    }};
 }
 
-macro_rules! return_hr_wrapped {
-    ($hr:expr, $v: expr) => {
+macro_rules! check_hr_wrapped {
+    ($hr:expr, $v: expr) => {{
         let hr = $hr;
         if hr == 0 {
-            return Ok($v);
+            Ok($v)
         } else {
-            return Err(HassleError::Win32Error(hr));
+            Err(HassleError::Win32Error(hr))
         }
-    };
+    }};
 }
 
 #[derive(Debug)]
@@ -90,23 +90,23 @@ impl DxcOperationResult {
 
     pub fn get_status(&self) -> Result<u32, HRESULT> {
         let mut status: u32 = 0;
-        return_hr!(unsafe { self.inner.get_status(&mut status) }, status);
+        check_hr!(unsafe { self.inner.get_status(&mut status) }, status)
     }
 
     pub fn get_result(&self) -> Result<DxcBlob, HRESULT> {
         let mut blob: ComPtr<IDxcBlob> = ComPtr::new();
-        return_hr!(
+        check_hr!(
             unsafe { self.inner.get_result(blob.as_mut_ptr()) },
             DxcBlob::new(blob)
-        );
+        )
     }
 
     pub fn get_error_buffer(&self) -> Result<DxcBlobEncoding, HRESULT> {
         let mut blob: ComPtr<IDxcBlobEncoding> = ComPtr::new();
-        return_hr!(
+        check_hr!(
             unsafe { self.inner.get_error_buffer(blob.as_mut_ptr()) },
             DxcBlobEncoding::new(blob)
-        );
+        )
     }
 }
 
@@ -408,13 +408,13 @@ impl DxcCompiler {
 
     pub fn disassemble(&self, blob: &DxcBlob) -> Result<DxcBlobEncoding, HRESULT> {
         let mut result_blob: ComPtr<IDxcBlobEncoding> = ComPtr::new();
-        return_hr!(
+        check_hr!(
             unsafe {
                 self.inner
                     .disassemble(blob.inner.as_ptr(), result_blob.as_mut_ptr())
             },
             DxcBlobEncoding::new(result_blob)
-        );
+        )
     }
 }
 
@@ -430,7 +430,7 @@ impl DxcLibrary {
 
     pub fn create_blob_with_encoding(&self, data: &[u8]) -> Result<DxcBlobEncoding, HRESULT> {
         let mut blob: ComPtr<IDxcBlobEncoding> = ComPtr::new();
-        return_hr!(
+        check_hr!(
             unsafe {
                 self.inner.create_blob_with_encoding_from_pinned(
                     data.as_ptr() as *const c_void,
@@ -440,7 +440,7 @@ impl DxcLibrary {
                 )
             },
             DxcBlobEncoding::new(blob)
-        );
+        )
     }
 
     pub fn create_blob_with_encoding_from_str(
@@ -450,7 +450,7 @@ impl DxcLibrary {
         let mut blob: ComPtr<IDxcBlobEncoding> = ComPtr::new();
         const CP_UTF8: u32 = 65001; // UTF-8 translation
 
-        return_hr!(
+        check_hr!(
             unsafe {
                 self.inner.create_blob_with_encoding_from_pinned(
                     text.as_ptr() as *const c_void,
@@ -460,7 +460,7 @@ impl DxcLibrary {
                 )
             },
             DxcBlobEncoding::new(blob)
-        );
+        )
     }
 
     pub fn get_blob_as_string(&self, blob: &DxcBlobEncoding) -> String {
@@ -521,26 +521,26 @@ impl Dxc {
 
     pub fn create_compiler(&self) -> Result<DxcCompiler, HassleError> {
         let mut compiler: ComPtr<IDxcCompiler2> = ComPtr::new();
-        return_hr_wrapped!(
+        check_hr_wrapped!(
             self.get_dxc_create_instance()?(
                 &CLSID_DxcCompiler,
                 &IID_IDxcCompiler2,
                 compiler.as_mut_ptr(),
             ),
             DxcCompiler::new(compiler, self.create_library()?)
-        );
+        )
     }
 
     pub fn create_library(&self) -> Result<DxcLibrary, HassleError> {
         let mut library: ComPtr<IDxcLibrary> = ComPtr::new();
-        return_hr_wrapped!(
+        check_hr_wrapped!(
             self.get_dxc_create_instance()?(
                 &CLSID_DxcLibrary,
                 &IID_IDxcLibrary,
                 library.as_mut_ptr(),
             ),
             DxcLibrary::new(library)
-        );
+        )
     }
 }
 
@@ -571,7 +571,7 @@ impl DxcValidator {
         let mut major = 0;
         let mut minor = 0;
 
-        return_hr! {
+        check_hr! {
             unsafe { version.get_version(&mut major, &mut minor) },
             (major, minor)
         }
@@ -629,13 +629,13 @@ impl Dxil {
 
     pub fn create_validator(&self) -> Result<DxcValidator, HassleError> {
         let mut validator: ComPtr<IDxcValidator> = ComPtr::new();
-        return_hr_wrapped!(
+        check_hr_wrapped!(
             self.get_dxc_create_instance()?(
                 &CLSID_DxcValidator,
                 &IID_IDxcValidator,
                 validator.as_mut_ptr(),
             ),
             DxcValidator::new(validator)
-        );
+        )
     }
 }


### PR DESCRIPTION
After a look at current code with @DBouma we decided that taking references to ComPtrs is ever so slightly more natural. More importantly DXC returns objects with their refcount already incremented (detached from an internal ComPtr by taking the pointer out without decreasing the refcount). To ensure adequate cleanup it is convenient if these pointers can't be left lingering around by accident.

Simplify conversion loops and in particular pointer magic in `get_children` to shove a raw pointer into a `ComPtr`, which com_rs was not designed for. The returned pointer 