### PR TITLE
Add optional path/directory argument for DXC/DXIL library

### DIFF
--- a/examples/file-ast.rs
+++ b/examples/file-ast.rs
@@ -77,7 +77,7 @@ fn main() {
 
     let args = vec![];
 
-    let dxc = Dxc::new().unwrap();
+    let dxc = Dxc::new(None).unwrap();
 
     let intellisense = dxc.create_intellisense().unwrap();
 

--- a/examples/intellisense-tu.rs
+++ b/examples/intellisense-tu.rs
@@ -7,7 +7,7 @@ fn main() {
 
     let args = vec![];
 
-    let dxc = Dxc::new().unwrap();
+    let dxc = Dxc::new(None).unwrap();
 
     let intellisense = dxc.create_intellisense().unwrap();
 


### PR DESCRIPTION
Depending on the platform/usecase the dlls/so's might not be available in PWD nor is it feasible for the application to change PWD on the fly. This does bloat the interface some but I don't feel like a static global and `hassle_rs::set_library_path()`  are all that pretty either.

