### PR TITLE
utils: Do not strip trailing nul from wide strings

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,9 @@ use thiserror::Error;
 use winapi::um::oleauto::SysStringLen;
 
 pub(crate) fn to_wide(msg: &str) -> Vec<WCHAR> {
-    widestring::WideCString::from_str(msg).unwrap().into_vec()
+    widestring::WideCString::from_str(msg)
+        .unwrap()
+        .into_vec_with_nul()
 }
 
 pub(crate) fn from_wide(wide: LPWSTR) -> String {


### PR DESCRIPTION
DXC (all the Windows string types using WCHAR under the hood, really) require wide strings to be terminated with a NUL character. If not, they'd use a BSTR that has a sneaky length prefix (#11), otherwise the length or ending of the string is unknown.

This has not caused any trouble before because into_vec performs the exact same conversion as into_vec_with_nul, *except* that it pops off the last character before returning the Vec. Only the size of it is reduced, the underlying memory is not reallocated and the final NUL byte is left in place.  However, in the event that a vector is shuffled around or modified we cannot permit ourselves to loose that trailing NUL.
