### PR TITLE
utils: Use unchecked widestring::WideStr for binary BSTR

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,7 @@ pub(crate) fn from_bstr(string: BSTR) -> String {
     unsafe {
         let len = SysStringLen(string) as usize;
 
-        let result = widestring::WideCStr::from_ptr_with_nul(string, len)
+        let result = widestring::WideStr::from_ptr(string, len)
             .to_string()
             .expect("widestring decode failed");
 


### PR DESCRIPTION
`BSTR` is a length-prefixed string type so that it can contain interior nul characters and other invalid or ill-formed UTF-16/UTF-32 data. Using that with a checked `WideCStr` is invalid however, which requires a single nul terminator at the end (conveniently `BSTR` includes a nul terminator beyond `SysStringLen`, but this is not part of the string itself); according to the docs ill-formed characters are still fine otherwise.
Use the "unchecked" `WideStr` type instead which allows interior nul values without affecting how the string is treated.

---

Was playing around with `widestring` yesterday and stumbled upon this `UStr`/`UCStr` convention. It's no big deal, likely never a problem IRL, but an easy fix nevertheless.