### PR TITLE
🖖Add fake dxil signing support

### DIFF
--- a/examples/copy-over-56.hlsl
+++ b/examples/copy-over-56.hlsl
@@ -1,0 +1,8 @@
+Texture2D<float4> g_input    : register(t0, space0);
+RWTexture2D<float4> g_output : register(u0, space0);
+
+[numthreads(8, 8, 1)]
+void copyCs(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+	g_output[dispatchThreadId.xy] = g_input[dispatchThreadId.xy];
+}

--- a/examples/copy-under-56.hlsl
+++ b/examples/copy-under-56.hlsl
@@ -1,0 +1,9 @@
+Texture2D<float4> g_input    : register(t0, space0);
+RWTexture2D<float4> g_output : register(u0, space0);
+
+[numthreads(8, 8, 1)]
+void copyCs(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+	g_output[dispatchThreadId.xy] = g_input[dispatchThreadId.xy * 1000];
+}
+

--- a/examples/validate-fake-signing.rs
+++ b/examples/validate-fake-signing.rs
@@ -1,0 +1,59 @@
+#[repr(C)]
+pub struct MinimalHeader {
+    four_cc: u32,
+    hash_digest: [u32; 4],
+}
+
+fn get_digest(buffer: &[u8]) -> [u32; 4] {
+    let buffer_ptr: *const u8 = buffer.as_ptr();
+    let header_ptr: *const MinimalHeader = buffer_ptr as *const _;
+    let header_ref: &MinimalHeader = unsafe { &*header_ptr };
+    let digest: [u32; 4] = [
+        header_ref.hash_digest[0],
+        header_ref.hash_digest[1],
+        header_ref.hash_digest[2],
+        header_ref.hash_digest[3],
+    ];
+    digest
+}
+
+use hassle_rs::{compile_hlsl, fake_sign_dxil_in_place, validate_dxil};
+
+fn main() {
+    let sources = [
+        include_str!("copy-over-56.hlsl"),
+        include_str!("copy-under-56.hlsl"),
+    ];
+
+    let mut all_matches = true;
+
+    for (idx, source) in sources.iter().enumerate() {
+        println!("Testing file: {}", idx);
+        let mut dxil = compile_hlsl("copy.hlsl", source, "copyCs", "cs_6_0", &[], &[]).unwrap();
+
+        let without_digest = get_digest(&dxil);
+
+        let validated_dxil = validate_dxil(&dxil).unwrap();
+
+        let with_digest = get_digest(&validated_dxil);
+
+        let result = fake_sign_dxil_in_place(&mut dxil);
+        assert!(result);
+
+        let fake_signed_digest = get_digest(&dxil);
+
+        println!(
+            "\tAfter compilation: {:?}\n\tAfter dxil.dll: {:?}\n\tAfter fake signing: {:?}",
+            without_digest, with_digest, fake_signed_digest
+        );
+
+        if fake_signed_digest != with_digest {
+            println!("---- Mismatch in file {} ----", idx);
+            all_matches &= true;
+        }
+    }
+
+    if all_matches {
+        println!("Success");
+    }
+}

--- a/src/fake_sign/mod.rs
+++ b/src/fake_sign/mod.rs
@@ -1,0 +1,98 @@
+mod modified_md5;
+use modified_md5::Context;
+
+#[repr(C)]
+struct FileHeader {
+    fourcc: u32,
+    hash_value: [u32; 4],
+    container_version: u32,
+    file_length: u32,
+    num_chunks: u32,
+}
+
+const DXIL_HEADER_CONTAINER_VERSION_OFFSET: usize = 20;
+const DXBC_FOURCC: u32 = u32::from_le_bytes([b'D', b'X', b'B', b'C']);
+
+fn read_fourcc(dxil: &[u8]) -> u32 {
+    let header: *const FileHeader = dxil.as_ptr() as *const _;
+    unsafe { (*header).fourcc }
+}
+
+fn read_file_length(dxil: &[u8]) -> u32 {
+    let header: *const FileHeader = dxil.as_ptr() as *const _;
+    unsafe { (*header).file_length }
+}
+
+fn write_hash_value(dxil: &mut [u8], state: [u32; 4]) {
+    let header: *mut FileHeader = dxil.as_mut_ptr() as *mut _;
+
+    unsafe {
+        (*header).hash_value.copy_from_slice(&state);
+    }
+}
+
+/// Helper function for signing DXIL binary blobs when
+/// `dxil.dll` might not be available (such as on Linux based
+/// platforms).
+/// This essentially performs the same functionality as `validate_dxil`
+/// but in a more cross platform way.
+///
+/// Ported from <https://github.com/baldurk/renderdoc/blob/v1.x/renderdoc/driver/shaders/dxbc/dxbc_container.cpp#L832>
+pub fn fake_sign_in_place(dxil: &mut [u8]) -> bool {
+    if read_fourcc(dxil) != DXBC_FOURCC {
+        return false;
+    }
+
+    if read_file_length(dxil) != dxil.len() as u32 {
+        return false;
+    }
+
+    // the hashable data starts immediately after the hash.
+    let data = &dxil[DXIL_HEADER_CONTAINER_VERSION_OFFSET..];
+
+    let num_bits: u32 = data.len() as u32 * 8;
+    let num_bits_part_2: u32 = (num_bits >> 2) | 1;
+    let left_over_len: u32 = data.len() as u32 % 64;
+
+    let (first_part, padding_part) = data.split_at(data.len() - left_over_len as usize);
+
+    let mut ctx = Context::new();
+    ctx.consume(&first_part);
+
+    let mut block = [0u8; 64];
+
+    if left_over_len >= 56 {
+        assert_eq!(padding_part.len(), left_over_len as usize);
+        ctx.consume(padding_part);
+
+        block[0..4].copy_from_slice(&0x80u32.to_le_bytes());
+        ctx.consume(&block[0..64 - left_over_len as usize]);
+
+        // the final block contains the number of bits in the first dword, and the weird upper bits
+        block[0..4].copy_from_slice(&num_bits.to_le_bytes());
+
+        // write to last dword
+        block[15 * 4..].copy_from_slice(&num_bits_part_2.to_le_bytes());
+
+        ctx.consume(&block);
+    } else {
+        ctx.consume(&num_bits.to_le_bytes());
+
+        if left_over_len != 0 {
+            ctx.consume(&padding_part)
+        }
+
+        let padding_bytes = (64 - left_over_len - 4) as usize;
+
+        block[0] = 0x80;
+        block[padding_bytes - 4..padding_bytes].copy_from_slice(&num_bits_part_2.to_le_bytes());
+        ctx.consume(&block[0..padding_bytes]);
+    }
+
+    // dxil signing is odd - it doesn't run the finalization step of the md5
+    // algorithm but instead pokes the hasher state directly into container
+
+    write_hash_value(dxil, ctx.state);
+
+    true
+}

--- a/src/fake_sign/mod.rs
+++ b/src/fake_sign/mod.rs
@@ -38,7 +38,7 @@ fn write_hash_value(dxil: &mut [u8], state: [u32; 4]) {
 /// but in a more cross platform way.
 ///
 /// Ported from <https://github.com/baldurk/renderdoc/blob/v1.x/renderdoc/driver/shaders/dxbc/dxbc_container.cpp#L832>
-pub fn fake_sign_in_place(dxil: &mut [u8]) -> bool {
+pub fn fake_sign_dxil_in_place(dxil: &mut [u8]) -> bool {
     if read_fourcc(dxil) != DXBC_FOURCC {
         return false;
     }

--- a/src/fake_sign/modified_md5.rs
+++ b/src/fake_sign/modified_md5.rs
@@ -1,6 +1,6 @@
 // https://github.com/stainless-steel/md5/blob/3236fc93c26af909923767e65be87e45c47aab89/LICENSE.md
-// 
-// Taken under the Apache 2.0 and MIT dual license to be included into this project with small 
+//
+// Taken under the Apache 2.0 and MIT dual license to be included into this project with small
 // modifications.
 //
 // Apache 2.0

--- a/src/fake_sign/modified_md5.rs
+++ b/src/fake_sign/modified_md5.rs
@@ -1,0 +1,250 @@
+// https://github.com/stainless-steel/md5/blob/3236fc93c26af909923767e65be87e45c47aab89/LICENSE.md
+// 
+// Taken under the Apache 2.0 and MIT dual license to be included into this project with small 
+// modifications.
+//
+// Apache 2.0
+//
+// Copyright 2015–2019 The md5 Developers
+//
+// Licensed under the Apache License, Version 2.0 (the “License”); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+//
+// MIT:
+//
+// Copyright 2015–2019 The md5 Developers
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the “Software”), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#[derive(Clone)]
+pub struct Context {
+    buffer: [u8; 64],
+    count: [u32; 2],
+    pub state: [u32; 4], // hassle-rs modification
+}
+
+impl Context {
+    #[inline]
+    pub fn new() -> Context {
+        Context {
+            buffer: [0; 64],
+            count: [0, 0],
+            state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476],
+        }
+    }
+
+    /// Consume data.
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
+        consume(self, data.as_ref());
+    }
+
+    /// Consume data.
+    #[cfg(target_pointer_width = "64")]
+    pub fn consume<T: AsRef<[u8]>>(&mut self, data: T) {
+        for chunk in data.as_ref().chunks(core::u32::MAX as usize) {
+            consume(self, chunk);
+        }
+    }
+}
+
+fn consume(
+    Context {
+        buffer,
+        count,
+        state,
+    }: &mut Context,
+    data: &[u8],
+) {
+    let mut input = [0u32; 16];
+    let mut k = ((count[0] >> 3) & 0x3f) as usize;
+    let length = data.len() as u32;
+    count[0] = count[0].wrapping_add(length << 3);
+    if count[0] < length << 3 {
+        count[1] = count[1].wrapping_add(1);
+    }
+    count[1] = count[1].wrapping_add(length >> 29);
+    for &value in data {
+        buffer[k] = value;
+        k += 1;
+        if k == 0x40 {
+            let mut j = 0;
+            for i in 0..16 {
+                input[i] = ((buffer[j + 3] as u32) << 24)
+                    | ((buffer[j + 2] as u32) << 16)
+                    | ((buffer[j + 1] as u32) << 8)
+                    | (buffer[j] as u32);
+                j += 4;
+            }
+            transform(state, &input);
+            k = 0;
+        }
+    }
+}
+
+fn transform(state: &mut [u32; 4], input: &[u32; 16]) {
+    let (mut a, mut b, mut c, mut d) = (state[0], state[1], state[2], state[3]);
+    macro_rules! add(
+        ($a:expr, $b:expr) => ($a.wrapping_add($b));
+    );
+    macro_rules! rotate(
+        ($x:expr, $n:expr) => (($x << $n) | ($x >> (32 - $n)));
+    );
+    {
+        macro_rules! F(
+            ($x:expr, $y:expr, $z:expr) => (($x & $y) | (!$x & $z));
+        );
+        macro_rules! T(
+            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
+                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
+                $a = rotate!($a, $s);
+                $a = add!($a, $b);
+            });
+        );
+        const S1: u32 = 7;
+        const S2: u32 = 12;
+        const S3: u32 = 17;
+        const S4: u32 = 22;
+        T!(a, b, c, d, input[0], S1, 3614090360);
+        T!(d, a, b, c, input[1], S2, 3905402710);
+        T!(c, d, a, b, input[2], S3, 606105819);
+        T!(b, c, d, a, input[3], S4, 3250441966);
+        T!(a, b, c, d, input[4], S1, 4118548399);
+        T!(d, a, b, c, input[5], S2, 1200080426);
+        T!(c, d, a, b, input[6], S3, 2821735955);
+        T!(b, c, d, a, input[7], S4, 4249261313);
+        T!(a, b, c, d, input[8], S1, 1770035416);
+        T!(d, a, b, c, input[9], S2, 2336552879);
+        T!(c, d, a, b, input[10], S3, 4294925233);
+        T!(b, c, d, a, input[11], S4, 2304563134);
+        T!(a, b, c, d, input[12], S1, 1804603682);
+        T!(d, a, b, c, input[13], S2, 4254626195);
+        T!(c, d, a, b, input[14], S3, 2792965006);
+        T!(b, c, d, a, input[15], S4, 1236535329);
+    }
+    {
+        macro_rules! F(
+            ($x:expr, $y:expr, $z:expr) => (($x & $z) | ($y & !$z));
+        );
+        macro_rules! T(
+            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
+                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
+                $a = rotate!($a, $s);
+                $a = add!($a, $b);
+            });
+        );
+        const S1: u32 = 5;
+        const S2: u32 = 9;
+        const S3: u32 = 14;
+        const S4: u32 = 20;
+        T!(a, b, c, d, input[1], S1, 4129170786);
+        T!(d, a, b, c, input[6], S2, 3225465664);
+        T!(c, d, a, b, input[11], S3, 643717713);
+        T!(b, c, d, a, input[0], S4, 3921069994);
+        T!(a, b, c, d, input[5], S1, 3593408605);
+        T!(d, a, b, c, input[10], S2, 38016083);
+        T!(c, d, a, b, input[15], S3, 3634488961);
+        T!(b, c, d, a, input[4], S4, 3889429448);
+        T!(a, b, c, d, input[9], S1, 568446438);
+        T!(d, a, b, c, input[14], S2, 3275163606);
+        T!(c, d, a, b, input[3], S3, 4107603335);
+        T!(b, c, d, a, input[8], S4, 1163531501);
+        T!(a, b, c, d, input[13], S1, 2850285829);
+        T!(d, a, b, c, input[2], S2, 4243563512);
+        T!(c, d, a, b, input[7], S3, 1735328473);
+        T!(b, c, d, a, input[12], S4, 2368359562);
+    }
+    {
+        macro_rules! F(
+            ($x:expr, $y:expr, $z:expr) => ($x ^ $y ^ $z);
+        );
+        macro_rules! T(
+            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
+                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
+                $a = rotate!($a, $s);
+                $a = add!($a, $b);
+            });
+        );
+        const S1: u32 = 4;
+        const S2: u32 = 11;
+        const S3: u32 = 16;
+        const S4: u32 = 23;
+        T!(a, b, c, d, input[5], S1, 4294588738);
+        T!(d, a, b, c, input[8], S2, 2272392833);
+        T!(c, d, a, b, input[11], S3, 1839030562);
+        T!(b, c, d, a, input[14], S4, 4259657740);
+        T!(a, b, c, d, input[1], S1, 2763975236);
+        T!(d, a, b, c, input[4], S2, 1272893353);
+        T!(c, d, a, b, input[7], S3, 4139469664);
+        T!(b, c, d, a, input[10], S4, 3200236656);
+        T!(a, b, c, d, input[13], S1, 681279174);
+        T!(d, a, b, c, input[0], S2, 3936430074);
+        T!(c, d, a, b, input[3], S3, 3572445317);
+        T!(b, c, d, a, input[6], S4, 76029189);
+        T!(a, b, c, d, input[9], S1, 3654602809);
+        T!(d, a, b, c, input[12], S2, 3873151461);
+        T!(c, d, a, b, input[15], S3, 530742520);
+        T!(b, c, d, a, input[2], S4, 3299628645);
+    }
+    {
+        macro_rules! F(
+            ($x:expr, $y:expr, $z:expr) => ($y ^ ($x | !$z));
+        );
+        macro_rules! T(
+            ($a:expr, $b:expr, $c:expr, $d:expr, $x:expr, $s:expr, $ac:expr) => ({
+                $a = add!(add!(add!($a, F!($b, $c, $d)), $x), $ac);
+                $a = rotate!($a, $s);
+                $a = add!($a, $b);
+            });
+        );
+        const S1: u32 = 6;
+        const S2: u32 = 10;
+        const S3: u32 = 15;
+        const S4: u32 = 21;
+        T!(a, b, c, d, input[0], S1, 4096336452);
+        T!(d, a, b, c, input[7], S2, 1126891415);
+        T!(c, d, a, b, input[14], S3, 2878612391);
+        T!(b, c, d, a, input[5], S4, 4237533241);
+        T!(a, b, c, d, input[12], S1, 1700485571);
+        T!(d, a, b, c, input[3], S2, 2399980690);
+        T!(c, d, a, b, input[10], S3, 4293915773);
+        T!(b, c, d, a, input[1], S4, 2240044497);
+        T!(a, b, c, d, input[8], S1, 1873313359);
+        T!(d, a, b, c, input[15], S2, 4264355552);
+        T!(c, d, a, b, input[6], S3, 2734768916);
+        T!(b, c, d, a, input[13], S4, 1309151649);
+        T!(a, b, c, d, input[4], S1, 4149444226);
+        T!(d, a, b, c, input[11], S2, 3174756917);
+        T!(c, d, a, b, input[2], S3, 718787259);
+        T!(b, c, d, a, input[9], S4, 3951481745);
+    }
+    state[0] = add!(state[0], a);
+    state[1] = add!(state[1], b);
+    state[2] = add!(state[2], c);
+    state[3] = add!(state[3], d);
+}

--- a/src/fake_sign/modified_md5.rs
+++ b/src/fake_sign/modified_md5.rs
@@ -94,8 +94,9 @@ fn consume(
         k += 1;
         if k == 0x40 {
             let mut j = 0;
-            for i in 0..16 {
-                input[i] = ((buffer[j + 3] as u32) << 24)
+            //for i in 0..16 {
+            for v in input.iter_mut() {
+                *v = ((buffer[j + 3] as u32) << 24)
                     | ((buffer[j + 2] as u32) << 16)
                     | ((buffer[j + 1] as u32) << 8)
                     | (buffer[j] as u32);

--- a/src/fake_sign/modified_md5.rs
+++ b/src/fake_sign/modified_md5.rs
@@ -94,8 +94,8 @@ fn consume(
         k += 1;
         if k == 0x40 {
             let mut j = 0;
-            //for i in 0..16 {
             for v in input.iter_mut() {
+                // hassle-rs modification to deal with clippy
                 *v = ((buffer[j + 3] as u32) << 24)
                     | ((buffer[j + 2] as u32) << 16)
                     | ((buffer[j + 1] as u32) << 8)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,10 +39,10 @@
 
 pub(crate) mod unknown;
 
+pub mod fake_sign;
 pub mod ffi;
 pub mod os;
 pub mod utils;
-pub mod fake_sign;
 
 #[macro_use]
 pub mod wrapper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,5 +51,6 @@ pub mod intellisense;
 
 pub use crate::ffi::*;
 pub use crate::utils::compile_hlsl;
+pub use crate::utils::fake_sign_dxil_in_place;
 pub use crate::utils::validate_dxil;
 pub use crate::wrapper::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) mod unknown;
 pub mod ffi;
 pub mod os;
 pub mod utils;
+pub mod fake_sign;
 
 #[macro_use]
 pub mod wrapper;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -157,3 +157,5 @@ pub fn validate_dxil(data: &[u8]) -> Result<Vec<u8>, HassleError> {
         }
     }
 }
+
+pub use crate::fake_sign::fake_sign_dxil_in_place;


### PR DESCRIPTION
This adds helper functions to sign dxil blobs without needing the `dxil.dll` present in the code repository. The code is a straight port from RenderDoc that has similar functionality.