### PR TITLE
utils: Propagate IncludeHandler file loading failures to DXC instead of a panic

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,7 +48,7 @@ impl DxcIncludeHandler for DefaultIncludeHandler {
         match std::fs::File::open(filename) {
             Ok(mut f) => {
                 let mut content = String::new();
-                f.read_to_string(&mut content).unwrap();
+                f.read_to_string(&mut content).ok()?;
                 Some(content)
             }
             Err(_) => None,


### PR DESCRIPTION
Not all file loading should be fallible; DXC usually invokes the loader with multiple paths depending on relative includes, and happily accepts and expects us to return `-2_147_024_894 // ERROR_FILE_NOT_FOUND / 0x80070002` for some.  As such the precedent should be to not panic but let DXC decide if file loading failures should be critical or simply result in a different path being tested.

In my case though the error seems to originate from DXIL compilation being largely untested when ran on Linux systems through the WinAadapter codepath.  In this particular stacktrace below DXC seems to "stat" (get file information) for the current working directory, and somehow ends up trying to open the directory as file through our include handler:

    #11 dxcutil::DxcArgsFileSystemImpl::TryFindOrOpen (this=<optimized out>, this@entry=0x5570a3b0ae10, lpFileName=lpFileName@entry=0x5570a3b5d0d0 L".../hassle-rs", index=<optimized out>)
        at .../DirectXShaderCompiler/tools/clang/tools/dxcompiler/dxcfilesystem.cpp:327
    #12 0x00007f6e64a41a8d in dxcutil::DxcArgsFileSystemImpl::GetFileAttributesW (this=0x5570a3b0ae10, lpFileName=0x5570a3b5d0d0 L".../hassle-rs")
        at .../DirectXShaderCompiler/tools/clang/tools/dxcompiler/dxcfilesystem.cpp:570
    #13 0x00007f6e64a42048 in dxcutil::DxcArgsFileSystemImpl::Stat (this=0x5570a3b0ae10, lpFileName=<optimized out>, Status=0x7fff9faec1e8)
        at .../DirectXShaderCompiler/tools/clang/tools/dxcompiler/dxcfilesystem.cpp:807
    #14 0x00007f6e64debc91 in llvm::sys::fs::status (Path=..., Result=...) at .../DirectXShaderCompiler/lib/Support/Unix/Path.inc:385
    #15 0x00007f6e64dec708 in llvm::sys::fs::current_path (result=...) at .../DirectXShaderCompiler/lib/Support/Unix/Path.inc:195
    #16 0x00007f6e64e64535 in clang::CodeGen::CGDebugInfo::getCurrentDirname (this=this@entry=0x5570a3b598f0)
        at .../DirectXShaderCompiler/tools/clang/lib/CodeGen/CGDebugInfo.cpp:301
    #17 0x00007f6e64e6230e in clang::CodeGen::CGDebugInfo::CreateCompileUnit (this=this@entry=0x5570a3b598f0)
        at .../DirectXShaderCompiler/tools/clang/lib/CodeGen/CGDebugInfo.cpp:369

This stacktrace originates from the following panic:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 21, kind: IsADirectory, message: "Is a directory" }', src/utils.rs:51:48
