### PR TITLE
os: Implement newtype for HRESULT with must_use and hexadecimal format

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -81,3 +81,41 @@ mod os_defs {
 }
 
 pub use os_defs::*;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+#[must_use]
+pub struct HRESULT(pub os_defs::HRESULT);
+impl HRESULT {
+    pub fn is_err(&self) -> bool {
+        self.0 < 0
+    }
+}
+
+impl From<i32> for HRESULT {
+    fn from(v: i32) -> Self {
+        Self(v)
+    }
+}
+
+impl std::fmt::Debug for HRESULT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as std::fmt::Display>::fmt(self, f)
+    }
+}
+
+impl std::fmt::Display for HRESULT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:#x}", self))
+    }
+}
+
+impl std::fmt::LowerHex for HRESULT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let prefix = if f.alternate() { "0x" } else { "" };
+        let bare_hex = format!("{:x}", self.0.abs());
+        // https://stackoverflow.com/a/44712309
+        f.pad_integral(self.0 >= 0, prefix, &bare_hex)
+        // <i32 as std::fmt::LowerHex>::fmt(&self.0, f)
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,7 +58,7 @@ impl DxcIncludeHandler for DefaultIncludeHandler {
 
 #[derive(Error, Debug)]
 pub enum HassleError {
-    #[error("Win32 error: {0:X}")]
+    #[error("Win32 error: {0:x}")]
     Win32Error(HRESULT),
     #[error("{0}")]
     CompileError(String),
@@ -117,7 +117,9 @@ pub fn compile_hlsl(
                 .get_error_buffer()
                 .map_err(HassleError::Win32Error)?;
             Err(HassleError::CompileError(
-                library.get_blob_as_string(&error_blob),
+                library
+                    .get_blob_as_string(&error_blob)
+                    .map_err(HassleError::Win32Error)?,
             ))
         }
         Ok(result) => {
@@ -152,7 +154,9 @@ pub fn validate_dxil(data: &[u8]) -> Result<Vec<u8>, HassleError> {
                 .get_error_buffer()
                 .map_err(HassleError::Win32Error)?;
             Err(HassleError::ValidationError(
-                library.get_blob_as_string(&error_blob),
+                library
+                    .get_blob_as_string(&error_blob)
+                    .map_err(HassleError::Win32Error)?,
             ))
         }
     }


### PR DESCRIPTION
Unify the use of `com_rs::HResult` into a newtyped `HRESULT` that allows us to place a `#[must_use]` annotation and in turn prevent missing errors from the API, which could lead to worse Undefined Behaviour.

In addition we can now use hexadecimal formatting for the `Display` and `Debug` traits making them much easier to read in `unwrap()` and similar scenarios.
