### PR TITLE
Consistently return `HassleError` and remove unneeded check macros

### DIFF
--- a/examples/intellisense-tu.rs
+++ b/examples/intellisense-tu.rs
@@ -43,17 +43,11 @@ fn main() {
 
     let child_cursors = cursor.get_all_children().unwrap();
 
+    assert_eq!(child_cursors[0].get_display_name().unwrap(), "g_input");
+    assert_eq!(child_cursors[1].get_display_name().unwrap(), "g_output");
     assert_eq!(
-        child_cursors[0].get_display_name(),
-        Ok("g_input".to_owned())
-    );
-    assert_eq!(
-        child_cursors[1].get_display_name(),
-        Ok("g_output".to_owned())
-    );
-    assert_eq!(
-        child_cursors[2].get_display_name(),
-        Ok("copyCs(uint3)".to_owned())
+        child_cursors[2].get_display_name().unwrap(),
+        "copyCs(uint3)"
     );
 
     for child_cursor in child_cursors {

--- a/src/intellisense/wrapper.rs
+++ b/src/intellisense/wrapper.rs
@@ -1,6 +1,6 @@
 use crate::intellisense::ffi::*;
-use crate::os::{CoTaskMemFree, BSTR, HRESULT, LPSTR};
-use crate::utils::HassleError;
+use crate::os::{CoTaskMemFree, BSTR, LPSTR};
+use crate::utils::Result;
 use crate::wrapper::Dxc;
 use com_rs::ComPtr;
 use std::ffi::CString;
@@ -15,46 +15,33 @@ impl DxcIntellisense {
         Self { inner }
     }
 
-    pub fn get_default_editing_tu_options(&self) -> Result<DxcTranslationUnitFlags, HRESULT> {
+    pub fn get_default_editing_tu_options(&self) -> Result<DxcTranslationUnitFlags> {
         let mut options: DxcTranslationUnitFlags = DxcTranslationUnitFlags::NONE;
-        unsafe {
-            check_hr!(
-                self.inner.get_default_editing_tu_options(&mut options),
-                options
-            )
-        }
+        unsafe { self.inner.get_default_editing_tu_options(&mut options) }
+            .result_with_success(options)
     }
 
-    pub fn create_index(&self) -> Result<DxcIndex, HRESULT> {
+    pub fn create_index(&self) -> Result<DxcIndex> {
         let mut index: ComPtr<IDxcIndex> = ComPtr::new();
-        unsafe {
-            check_hr!(
-                self.inner.create_index(index.as_mut_ptr()),
-                DxcIndex::new(index)
-            )
-        }
+        unsafe { self.inner.create_index(index.as_mut_ptr()) }.result()?;
+        Ok(DxcIndex::new(index))
     }
 
-    pub fn create_unsaved_file(
-        &self,
-        file_name: &str,
-        contents: &str,
-    ) -> Result<DxcUnsavedFile, HRESULT> {
+    pub fn create_unsaved_file(&self, file_name: &str, contents: &str) -> Result<DxcUnsavedFile> {
         let c_file_name = CString::new(file_name).expect("Failed to convert `file_name`");
         let c_contents = CString::new(contents).expect("Failed to convert `contents`");
 
         let mut file: ComPtr<IDxcUnsavedFile> = ComPtr::new();
         unsafe {
-            check_hr!(
-                self.inner.create_unsaved_file(
-                    c_file_name.as_ptr(),
-                    c_contents.as_ptr(),
-                    contents.len() as u32,
-                    file.as_mut_ptr()
-                ),
-                DxcUnsavedFile::new(file)
+            self.inner.create_unsaved_file(
+                c_file_name.as_ptr(),
+                c_contents.as_ptr(),
+                contents.len() as u32,
+                file.as_mut_ptr(),
             )
         }
+        .result()?;
+        Ok(DxcUnsavedFile::new(file))
     }
 }
 
@@ -76,7 +63,7 @@ impl DxcIndex {
         args: &[&str],
         unsaved_files: &[&DxcUnsavedFile],
         options: DxcTranslationUnitFlags,
-    ) -> Result<DxcTranslationUnit, HRESULT> {
+    ) -> Result<DxcTranslationUnit> {
         let c_source_filename =
             CString::new(source_filename).expect("Failed to convert `source_filename`");
 
@@ -86,30 +73,30 @@ impl DxcIndex {
             uf.push(unsaved_file.inner.as_ptr());
         }
 
+        let mut c_args: Vec<CString> = vec![];
+        let mut cliargs = vec![];
+
+        for arg in args.iter() {
+            let c_arg = CString::new(*arg).expect("Failed to convert `arg`");
+            cliargs.push(c_arg.as_ptr() as *const u8);
+            c_args.push(c_arg);
+        }
+
+        let mut tu: ComPtr<IDxcTranslationUnit> = ComPtr::new();
+
         unsafe {
-            let mut c_args: Vec<CString> = vec![];
-            let mut cliargs = vec![];
-
-            for arg in args.iter() {
-                let c_arg = CString::new(*arg).expect("Failed to convert `arg`");
-                cliargs.push(c_arg.as_ptr() as *const u8);
-                c_args.push(c_arg);
-            }
-
-            let mut tu: ComPtr<IDxcTranslationUnit> = ComPtr::new();
-            check_hr!(
-                self.inner.parse_translation_unit(
-                    c_source_filename.as_ptr() as *const u8,
-                    cliargs.as_ptr(),
-                    cliargs.len() as i32,
-                    uf.as_ptr(),
-                    uf.len() as u32,
-                    options,
-                    tu.as_mut_ptr()
-                ),
-                DxcTranslationUnit::new(tu)
+            self.inner.parse_translation_unit(
+                c_source_filename.as_ptr() as *const u8,
+                cliargs.as_ptr(),
+                cliargs.len() as i32,
+                uf.as_ptr(),
+                uf.len() as u32,
+                options,
+                tu.as_mut_ptr(),
             )
         }
+        .result()?;
+        Ok(DxcTranslationUnit::new(tu))
     }
 }
 
@@ -119,9 +106,9 @@ pub struct DxcUnsavedFile {
 }
 
 impl DxcUnsavedFile {
-    pub fn get_length(&self) -> Result<u32, HRESULT> {
+    pub fn get_length(&self) -> Result<u32> {
         let mut length: u32 = 0;
-        unsafe { check_hr!(self.inner.get_length(&mut length), length) }
+        unsafe { self.inner.get_length(&mut length) }.result_with_success(length)
     }
 
     fn new(inner: ComPtr<IDxcUnsavedFile>) -> Self {
@@ -139,24 +126,16 @@ impl DxcTranslationUnit {
         DxcTranslationUnit { inner }
     }
 
-    pub fn get_file(&self, name: &[u8]) -> Result<DxcFile, HRESULT> {
+    pub fn get_file(&self, name: &[u8]) -> Result<DxcFile> {
         let mut file: ComPtr<IDxcFile> = ComPtr::new();
-        unsafe {
-            check_hr!(
-                self.inner.get_file(name.as_ptr(), file.as_mut_ptr()),
-                DxcFile::new(file)
-            )
-        }
+        unsafe { self.inner.get_file(name.as_ptr(), file.as_mut_ptr()) }.result()?;
+        Ok(DxcFile::new(file))
     }
 
-    pub fn get_cursor(&self) -> Result<DxcCursor, HRESULT> {
+    pub fn get_cursor(&self) -> Result<DxcCursor> {
         let mut cursor: ComPtr<IDxcCursor> = ComPtr::new();
-        unsafe {
-            check_hr!(
-                self.inner.get_cursor(cursor.as_mut_ptr()),
-                DxcCursor::new(cursor)
-            )
-        }
+        unsafe { self.inner.get_cursor(cursor.as_mut_ptr()) }.result()?;
+        Ok(DxcCursor::new(cursor))
     }
 }
 
@@ -170,32 +149,30 @@ impl DxcCursor {
         DxcCursor { inner }
     }
 
-    pub fn get_children(&self, skip: u32, max_count: u32) -> Result<Vec<DxcCursor>, HRESULT> {
-        unsafe {
-            let mut result: *mut *mut IDxcCursor = std::ptr::null_mut();
-            let mut result_length: u32 = 0;
+    pub fn get_children(&self, skip: u32, max_count: u32) -> Result<Vec<DxcCursor>> {
+        let mut result: *mut *mut IDxcCursor = std::ptr::null_mut();
+        let mut result_length: u32 = 0;
 
-            check_hr!(
-                self.inner
-                    .get_children(skip, max_count, &mut result_length, &mut result),
-                {
-                    // get_children allocates a buffer to pass the result in.
-                    let child_cursors = std::slice::from_raw_parts(result, result_length as usize)
-                        .iter()
-                        .map(|&ptr| {
-                            let mut childcursor = ComPtr::<IDxcCursor>::new();
-                            *childcursor.as_mut_ptr() = ptr;
-                            DxcCursor::new(childcursor)
-                        })
-                        .collect::<Vec<_>>();
-                    CoTaskMemFree(result as *mut _);
-                    child_cursors
-                }
-            )
+        unsafe {
+            self.inner
+                .get_children(skip, max_count, &mut result_length, &mut result)
         }
+        .result()?;
+
+        // get_children allocates a buffer to pass the result in.
+        let child_cursors = unsafe { std::slice::from_raw_parts(result, result_length as usize) }
+            .iter()
+            .map(|&ptr| {
+                let mut childcursor = ComPtr::<IDxcCursor>::new();
+                *childcursor.as_mut_ptr() = ptr;
+                DxcCursor::new(childcursor)
+            })
+            .collect::<Vec<_>>();
+        unsafe { CoTaskMemFree(result as *mut _) };
+        Ok(child_cursors)
     }
 
-    pub fn get_all_children(&self) -> Result<Vec<DxcCursor>, HRESULT> {
+    pub fn get_all_children(&self) -> Result<Vec<DxcCursor>> {
         const MAX_CHILDREN_PER_CHUNK: u32 = 10;
         let mut children = vec![];
 
@@ -209,139 +186,91 @@ impl DxcCursor {
         }
     }
 
-    pub fn get_extent(&self) -> Result<DxcSourceRange, HRESULT> {
-        unsafe {
-            let mut range: ComPtr<IDxcSourceRange> = ComPtr::new();
-            check_hr!(
-                self.inner.get_extent(range.as_mut_ptr()),
-                DxcSourceRange::new(range)
-            )
-        }
+    pub fn get_extent(&self) -> Result<DxcSourceRange> {
+        let mut range: ComPtr<IDxcSourceRange> = ComPtr::new();
+        unsafe { self.inner.get_extent(range.as_mut_ptr()) }.result()?;
+        Ok(DxcSourceRange::new(range))
     }
 
-    pub fn get_location(&self) -> Result<DxcSourceLocation, HRESULT> {
-        unsafe {
-            let mut location: ComPtr<IDxcSourceLocation> = ComPtr::new();
-            check_hr!(
-                self.inner.get_location(location.as_mut_ptr()),
-                DxcSourceLocation::new(location)
-            )
-        }
+    pub fn get_location(&self) -> Result<DxcSourceLocation> {
+        let mut location: ComPtr<IDxcSourceLocation> = ComPtr::new();
+        unsafe { self.inner.get_location(location.as_mut_ptr()) }.result()?;
+        Ok(DxcSourceLocation::new(location))
     }
 
-    pub fn get_display_name(&self) -> Result<String, HRESULT> {
-        unsafe {
-            let mut name: BSTR = std::ptr::null_mut();
-            check_hr!(
-                self.inner.get_display_name(&mut name),
-                crate::utils::from_bstr(name)
-            )
-        }
+    pub fn get_display_name(&self) -> Result<String> {
+        let mut name: BSTR = std::ptr::null_mut();
+        unsafe { self.inner.get_display_name(&mut name) }.result()?;
+        Ok(crate::utils::from_bstr(name))
     }
 
-    pub fn get_formatted_name(&self, formatting: DxcCursorFormatting) -> Result<String, HRESULT> {
-        unsafe {
-            let mut name: BSTR = std::ptr::null_mut();
-            check_hr!(
-                self.inner.get_formatted_name(formatting, &mut name),
-                crate::utils::from_bstr(name)
-            )
-        }
+    pub fn get_formatted_name(&self, formatting: DxcCursorFormatting) -> Result<String> {
+        let mut name: BSTR = std::ptr::null_mut();
+        unsafe { self.inner.get_formatted_name(formatting, &mut name) }.result()?;
+        Ok(crate::utils::from_bstr(name))
     }
 
-    pub fn get_qualified_name(&self, include_template_args: bool) -> Result<String, HRESULT> {
+    pub fn get_qualified_name(&self, include_template_args: bool) -> Result<String> {
+        let mut name: BSTR = std::ptr::null_mut();
         unsafe {
-            let mut name: BSTR = std::ptr::null_mut();
-            check_hr!(
-                self.inner
-                    .get_qualified_name(include_template_args, &mut name),
-                crate::utils::from_bstr(name)
-            )
+            self.inner
+                .get_qualified_name(include_template_args, &mut name)
         }
+        .result()?;
+        Ok(crate::utils::from_bstr(name))
     }
 
-    pub fn get_kind(&self) -> Result<DxcCursorKind, HRESULT> {
-        unsafe {
-            let mut cursor_kind: DxcCursorKind = DxcCursorKind::UNEXPOSED_DECL;
-            check_hr!(self.inner.get_kind(&mut cursor_kind), cursor_kind)
-        }
+    pub fn get_kind(&self) -> Result<DxcCursorKind> {
+        let mut cursor_kind: DxcCursorKind = DxcCursorKind::UNEXPOSED_DECL;
+        unsafe { self.inner.get_kind(&mut cursor_kind) }.result_with_success(cursor_kind)
     }
 
-    pub fn get_kind_flags(&self) -> Result<DxcCursorKindFlags, HRESULT> {
-        unsafe {
-            let mut cursor_kind_flags: DxcCursorKindFlags = DxcCursorKindFlags::NONE;
-            check_hr!(
-                self.inner.get_kind_flags(&mut cursor_kind_flags),
-                cursor_kind_flags
-            )
-        }
+    pub fn get_kind_flags(&self) -> Result<DxcCursorKindFlags> {
+        let mut cursor_kind_flags: DxcCursorKindFlags = DxcCursorKindFlags::NONE;
+        unsafe { self.inner.get_kind_flags(&mut cursor_kind_flags) }
+            .result_with_success(cursor_kind_flags)
     }
 
-    pub fn get_semantic_parent(&self) -> Result<DxcCursor, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcCursor>::new();
-            check_hr!(
-                self.inner.get_semantic_parent(inner.as_mut_ptr()),
-                DxcCursor::new(inner)
-            )
-        }
+    pub fn get_semantic_parent(&self) -> Result<DxcCursor> {
+        let mut inner = ComPtr::<IDxcCursor>::new();
+        unsafe { self.inner.get_semantic_parent(inner.as_mut_ptr()) }.result()?;
+        Ok(DxcCursor::new(inner))
     }
 
-    pub fn get_lexical_parent(&self) -> Result<DxcCursor, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcCursor>::new();
-            check_hr!(
-                self.inner.get_lexical_parent(inner.as_mut_ptr()),
-                DxcCursor::new(inner)
-            )
-        }
+    pub fn get_lexical_parent(&self) -> Result<DxcCursor> {
+        let mut inner = ComPtr::<IDxcCursor>::new();
+        unsafe { self.inner.get_lexical_parent(inner.as_mut_ptr()) }.result()?;
+        Ok(DxcCursor::new(inner))
     }
 
-    pub fn get_cursor_type(&self) -> Result<DxcType, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcType>::new();
-            check_hr!(
-                self.inner.get_cursor_type(inner.as_mut_ptr()),
-                DxcType::new(inner)
-            )
-        }
+    pub fn get_cursor_type(&self) -> Result<DxcType> {
+        let mut inner = ComPtr::<IDxcType>::new();
+        unsafe { self.inner.get_cursor_type(inner.as_mut_ptr()) }.result()?;
+        Ok(DxcType::new(inner))
     }
 
-    pub fn get_num_arguments(&self) -> Result<i32, HRESULT> {
-        unsafe {
-            let mut result: i32 = 0;
-            check_hr!(self.inner.get_num_arguments(&mut result), result)
-        }
+    pub fn get_num_arguments(&self) -> Result<i32> {
+        let mut result: i32 = 0;
+
+        unsafe { self.inner.get_num_arguments(&mut result) }.result_with_success(result)
     }
 
-    pub fn get_argument_at(&self, index: i32) -> Result<DxcCursor, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcCursor>::new();
-            check_hr!(
-                self.inner.get_argument_at(index, inner.as_mut_ptr()),
-                DxcCursor::new(inner)
-            )
-        }
+    pub fn get_argument_at(&self, index: i32) -> Result<DxcCursor> {
+        let mut inner = ComPtr::<IDxcCursor>::new();
+        unsafe { self.inner.get_argument_at(index, inner.as_mut_ptr()) }.result()?;
+        Ok(DxcCursor::new(inner))
     }
 
-    pub fn get_referenced_cursor(&self) -> Result<DxcCursor, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcCursor>::new();
-            check_hr!(
-                self.inner.get_referenced_cursor(inner.as_mut_ptr()),
-                DxcCursor::new(inner)
-            )
-        }
+    pub fn get_referenced_cursor(&self) -> Result<DxcCursor> {
+        let mut inner = ComPtr::<IDxcCursor>::new();
+        unsafe { self.inner.get_referenced_cursor(inner.as_mut_ptr()) }.result()?;
+        Ok(DxcCursor::new(inner))
     }
 
-    pub fn get_definition_cursor(&self) -> Result<DxcCursor, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcCursor>::new();
-            check_hr!(
-                self.inner.get_definition_cursor(inner.as_mut_ptr()),
-                DxcCursor::new(inner)
-            )
-        }
+    pub fn get_definition_cursor(&self) -> Result<DxcCursor> {
+        let mut inner = ComPtr::<IDxcCursor>::new();
+        unsafe { self.inner.get_definition_cursor(inner.as_mut_ptr()) }.result()?;
+        Ok(DxcCursor::new(inner))
     }
 
     pub fn find_references_in_file(
@@ -349,82 +278,67 @@ impl DxcCursor {
         file: &DxcFile,
         skip: u32,
         top: u32,
-    ) -> Result<Vec<DxcCursor>, HRESULT> {
-        unsafe {
-            let mut result: *mut *mut IDxcCursor = std::ptr::null_mut();
-            let mut result_length: u32 = 0;
+    ) -> Result<Vec<DxcCursor>> {
+        let mut result: *mut *mut IDxcCursor = std::ptr::null_mut();
+        let mut result_length: u32 = 0;
 
-            check_hr!(
-                self.inner.find_references_in_file(
-                    file.inner.as_ptr(),
-                    skip,
-                    top,
-                    &mut result_length,
-                    &mut result
-                ),
-                {
-                    // find_references_in_file allocates a buffer to pass the result in.
-                    let child_cursors = std::slice::from_raw_parts(result, result_length as usize)
-                        .iter()
-                        .map(|&ptr| {
-                            let mut childcursor = ComPtr::<IDxcCursor>::new();
-                            *childcursor.as_mut_ptr() = ptr;
-                            DxcCursor::new(childcursor)
-                        })
-                        .collect::<Vec<_>>();
-                    CoTaskMemFree(result as *mut _);
-                    child_cursors
-                }
+        unsafe {
+            self.inner.find_references_in_file(
+                file.inner.as_ptr(),
+                skip,
+                top,
+                &mut result_length,
+                &mut result,
             )
         }
+        .result()?;
+
+        // find_references_in_file allocates a buffer to pass the result in.
+        let child_cursors = unsafe { std::slice::from_raw_parts(result, result_length as usize) }
+            .iter()
+            .map(|&ptr| {
+                let mut childcursor = ComPtr::<IDxcCursor>::new();
+                *childcursor.as_mut_ptr() = ptr;
+                DxcCursor::new(childcursor)
+            })
+            .collect::<Vec<_>>();
+        unsafe { CoTaskMemFree(result as *mut _) };
+        Ok(child_cursors)
     }
 
-    pub fn get_spelling(&self) -> Result<String, HRESULT> {
+    pub fn get_spelling(&self) -> Result<String> {
+        let mut spelling: LPSTR = std::ptr::null_mut();
+        unsafe { self.inner.get_spelling(&mut spelling) }.result()?;
+        Ok(crate::utils::from_lpstr(spelling))
+    }
+
+    pub fn is_equal_to(&self, other: &DxcCursor) -> Result<bool> {
+        let mut result: bool = false;
+        unsafe { self.inner.is_equal_to(other.inner.as_ptr(), &mut result) }
+            .result_with_success(result)
+    }
+
+    pub fn is_null(&mut self) -> Result<bool> {
+        let mut result: bool = false;
+        unsafe { IDxcCursor::is_null(&self.inner, &mut result) }.result_with_success(result)
+    }
+
+    pub fn is_definition(&self) -> Result<bool> {
+        let mut result: bool = false;
+        unsafe { self.inner.is_definition(&mut result) }.result_with_success(result)
+    }
+
+    pub fn get_snapped_child(&self, location: &DxcSourceLocation) -> Result<DxcCursor> {
+        let mut inner = ComPtr::<IDxcCursor>::new();
         unsafe {
-            let mut spelling: LPSTR = std::ptr::null_mut();
-            check_hr!(
-                self.inner.get_spelling(&mut spelling),
-                crate::utils::from_lpstr(spelling)
-            )
+            self.inner
+                .get_snapped_child(location.inner.as_ptr(), inner.as_mut_ptr())
         }
+        .result()?;
+        Ok(DxcCursor::new(inner))
     }
 
-    pub fn is_equal_to(&self, other: &DxcCursor) -> Result<bool, HRESULT> {
-        unsafe {
-            let mut result: bool = false;
-            check_hr!(
-                self.inner.is_equal_to(other.inner.as_ptr(), &mut result),
-                result
-            )
-        }
-    }
-
-    pub fn is_null(&mut self) -> Result<bool, HRESULT> {
-        unsafe {
-            let mut result: bool = false;
-            check_hr!(IDxcCursor::is_null(&self.inner, &mut result), result)
-        }
-    }
-
-    pub fn is_definition(&self) -> Result<bool, HRESULT> {
-        unsafe {
-            let mut result: bool = false;
-            check_hr!(self.inner.is_definition(&mut result), result)
-        }
-    }
-
-    pub fn get_snapped_child(&self, location: &DxcSourceLocation) -> Result<DxcCursor, HRESULT> {
-        unsafe {
-            let mut inner = ComPtr::<IDxcCursor>::new();
-            check_hr!(
-                self.inner
-                    .get_snapped_child(location.inner.as_ptr(), inner.as_mut_ptr()),
-                DxcCursor::new(inner)
-            )
-        }
-    }
-
-    pub fn get_source<'a>(&self, source: &'a str) -> Result<&'a str, HRESULT> {
+    pub fn get_source<'a>(&self, source: &'a str) -> Result<&'a str> {
         let range = self.get_extent()?;
 
         let DxcSourceOffsets {
@@ -448,14 +362,10 @@ impl DxcType {
         DxcType { inner }
     }
 
-    pub fn get_spelling(&self) -> Result<String, HRESULT> {
-        unsafe {
-            let mut spelling: LPSTR = std::ptr::null_mut();
-            check_hr!(
-                self.inner.get_spelling(&mut spelling),
-                crate::utils::from_lpstr(spelling)
-            )
-        }
+    pub fn get_spelling(&self) -> Result<String> {
+        let mut spelling: LPSTR = std::ptr::null_mut();
+        unsafe { self.inner.get_spelling(&mut spelling) }
+            .result_with_success(crate::utils::from_lpstr(spelling))
     }
 }
 
@@ -482,18 +392,15 @@ pub struct DxcSourceRange {
 }
 
 impl DxcSourceRange {
-    pub fn get_offsets(&self) -> Result<DxcSourceOffsets, HRESULT> {
-        unsafe {
-            let mut start_offset: u32 = 0;
-            let mut end_offset: u32 = 0;
-            check_hr!(
-                self.inner.get_offsets(&mut start_offset, &mut end_offset),
-                DxcSourceOffsets {
-                    start_offset,
-                    end_offset
-                }
-            )
-        }
+    pub fn get_offsets(&self) -> Result<DxcSourceOffsets> {
+        let mut start_offset: u32 = 0;
+        let mut end_offset: u32 = 0;
+        unsafe { self.inner.get_offsets(&mut start_offset, &mut end_offset) }.result_with_success(
+            DxcSourceOffsets {
+                start_offset,
+                end_offset,
+            },
+        )
     }
 }
 
@@ -515,15 +422,15 @@ impl DxcFile {
 }
 
 impl Dxc {
-    pub fn create_intellisense(&self) -> Result<DxcIntellisense, HassleError> {
+    pub fn create_intellisense(&self) -> Result<DxcIntellisense> {
         let mut intellisense: ComPtr<IDxcIntelliSense> = ComPtr::new();
-        check_hr_wrapped!(
-            self.get_dxc_create_instance()?(
-                &CLSID_DxcIntelliSense,
-                &IID_IDxcIntelliSense,
-                intellisense.as_mut_ptr(),
-            ),
-            DxcIntellisense::new(intellisense)
+
+        self.get_dxc_create_instance()?(
+            &CLSID_DxcIntelliSense,
+            &IID_IDxcIntelliSense,
+            intellisense.as_mut_ptr(),
         )
+        .result()?;
+        Ok(DxcIntellisense::new(intellisense))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,10 @@ pub mod fake_sign;
 pub mod ffi;
 pub mod os;
 pub mod utils;
-
-#[macro_use]
 pub mod wrapper;
 
 pub mod intellisense;
 
 pub use crate::ffi::*;
-pub use crate::utils::compile_hlsl;
-pub use crate::utils::fake_sign_dxil_in_place;
-pub use crate::utils::validate_dxil;
+pub use crate::utils::{compile_hlsl, fake_sign_dxil_in_place, validate_dxil, HassleError, Result};
 pub use crate::wrapper::*;


### PR DESCRIPTION
Depends on #29

Our public API becomes a lot cleaner when returning `HassleError` everywhere, helped by the fact that `HRESULT`s from the low-level COM API is a newtype with support for functions to convert to `Result<>` easily.  These can be short-circuit-returned in a more Rust'y way through the questionmark operator instead of wrapping everything in large macro calls.  This change is based on a similar approach in the Ash crate: https://github.com/MaikKlein/ash/pull/339/files
