### PR TITLE
ci: Speed up by removing `touch` hack and caching intermediates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          profile: minimal
           override: true
           components: rustfmt, clippy
       - name: Cargo check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,6 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-      # Update mtime on all our files so that `clippy` rechecks them
-      - name: Touch source files for clippy recheck
-        run: find -path ./target -prune -o -name "*.rs" -exec touch {} +
-        shell: bash
       - name: Cargo clippy
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
- ci: Remove mtime update hack; `clippy` now re-runs after `check`
- ci: Cache crate downloads and intermediates between runs
