### PR TITLE
Use `.cast()` to not accidentally const_cast, fix Android char type

### DIFF
--- a/src/intellisense/wrapper.rs
+++ b/src/intellisense/wrapper.rs
@@ -78,7 +78,7 @@ impl DxcIndex {
 
         for arg in args.iter() {
             let c_arg = CString::new(*arg).expect("Failed to convert `arg`");
-            cliargs.push(c_arg.as_ptr() as *const u8);
+            cliargs.push(c_arg.as_ptr().cast());
             c_args.push(c_arg);
         }
 
@@ -86,7 +86,7 @@ impl DxcIndex {
 
         unsafe {
             self.inner.parse_translation_unit(
-                c_source_filename.as_ptr() as *const u8,
+                c_source_filename.as_ptr().cast(),
                 cliargs.as_ptr(),
                 cliargs.len() as i32,
                 uf.as_ptr(),
@@ -168,7 +168,7 @@ impl DxcCursor {
                 DxcCursor::new(childcursor)
             })
             .collect::<Vec<_>>();
-        unsafe { CoTaskMemFree(result as *mut _) };
+        unsafe { CoTaskMemFree(result.cast()) };
         Ok(child_cursors)
     }
 
@@ -302,7 +302,7 @@ impl DxcCursor {
                 DxcCursor::new(childcursor)
             })
             .collect::<Vec<_>>();
-        unsafe { CoTaskMemFree(result as *mut _) };
+        unsafe { CoTaskMemFree(result.cast()) };
         Ok(child_cursors)
     }
 

--- a/src/os.rs
+++ b/src/os.rs
@@ -14,7 +14,7 @@ mod os_defs {
 
 #[cfg(not(windows))]
 mod os_defs {
-    pub type CHAR = i8;
+    pub type CHAR = std::os::raw::c_char;
     pub type UINT = u32;
     pub type WCHAR = widestring::WideChar;
     pub type OLECHAR = WCHAR;


### PR DESCRIPTION
Depends on #26

Clean up casts to use `.cast()` to change the type while making it impossible to accidentally turn a `*const` into a `*mut`.

Also makes sure that the correct const-ness types, ie lpCstr and friends are used when the pointed-to data needs not to be modified: `*mut` coerces to `*const` (but for obvious reasons not the other way around).

Finally, fix the `CHAR` type to use `std::os::raw::c_char` which is defined to `u8` on Arm architectures and i8 on our x64 machines.
