### PR TITLE
wrapper: Add Android library path

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -482,7 +482,7 @@ fn dxcompiler_lib_name() -> &'static Path {
     Path::new("dxcompiler.dll")
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn dxcompiler_lib_name() -> &'static Path {
     Path::new("./libdxcompiler.so")
 }


### PR DESCRIPTION
On Android - which is a Linux/Unix platform - the library path remains the same.
