### PR TITLE
ci: Drop nightly build/lint tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust: [stable, nightly]
+        rust: [stable]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There is not much point "preparing hassle-rs for the future" if the lints are false positives and prevent us from submitting or having actually good code.  Overnight two false positives got introduced: https://github.com/Traverse-Research/hassle-rs/runs/5006913943?check_suite_focus=true. One needs the borrow to satisfy a peculiar `From`/`Into` implementation, and the `&mut Vec<>` is pushed to which makes it impossible to turn this into a mutable borrow of a slice.
