### PR TITLE
Moving from com-rs to tinycom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
 libloading = "0.7.0"
-tinycom = { git = "https://github.com/legion-labs/tinycom-rs", branch = "main" }
+tinycom = "0.1.0"
 bitflags = "1.2.1"
 widestring = "0.5.0"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,7 @@ homepage = "https://github.com/Traverse-Research/hassle-rs"
 repository = "https://github.com/Traverse-Research/hassle-rs"
 keywords = ["shader", "pipeline", "hlsl", "dxc", "intellisense"]
 categories = ["rendering", "rendering::graphics-api"]
-include = [
-    "src/*.rs",
-    "src/intellisense/*.rs",
-    "Cargo.toml",
-]
+include = ["src/*.rs", "src/intellisense/*.rs", "Cargo.toml"]
 documentation = "https://docs.rs/hassle-rs"
 
 [badges]
@@ -25,7 +21,7 @@ default-target = "x86_64-pc-windows-msvc"
 
 [dependencies]
 libloading = "0.7.0"
-com-rs = "0.2.1"
+tinycom = { git = "https://github.com/legion-labs/tinycom-rs", branch = "main" }
 bitflags = "1.2.1"
 widestring = "0.4.2"
 thiserror = "1.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,8 +3,8 @@
 
 use crate::os::{HRESULT, LPCWSTR, LPWSTR};
 pub(crate) use crate::unknown::IDxcUnknownShim;
-use com_rs::{com_interface, iid, IUnknown, IID};
 use std::ffi::c_void;
+use tinycom::{com_interface, iid, IUnknown, IID};
 
 pub type DxcCreateInstanceProc =
     extern "system" fn(rclsid: &IID, riid: &IID, ppv: *mut *mut c_void) -> HRESULT;

--- a/src/intellisense/ffi.rs
+++ b/src/intellisense/ffi.rs
@@ -1,7 +1,7 @@
 use crate::os::{BSTR, HRESULT, LPCSTR, LPSTR};
 pub(crate) use crate::unknown::IDxcUnknownShim;
 use bitflags::bitflags;
-use com_rs::{com_interface, iid, IUnknown};
+use tinycom::{com_interface, iid, IUnknown};
 
 bitflags! {
     pub struct DxcGlobalOptions : u32 {

--- a/src/intellisense/wrapper.rs
+++ b/src/intellisense/wrapper.rs
@@ -2,8 +2,8 @@ use crate::intellisense::ffi::*;
 use crate::os::{CoTaskMemFree, BSTR, HRESULT, LPSTR};
 use crate::utils::HassleError;
 use crate::wrapper::Dxc;
-use com_rs::ComPtr;
 use std::ffi::CString;
+use tinycom::ComPtr;
 
 #[derive(Debug)]
 pub struct DxcIntellisense {

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -1,10 +1,7 @@
 #[cfg(not(windows))]
 use crate::os::HRESULT;
-use com_rs::{com_interface, IUnknown, IID};
 
-extern "C" {
-    static IID_IUnknown: IID;
-}
+use tinycom::{com_interface, IID_IUnknown, IUnknown};
 
 #[cfg(not(windows))]
 // Steal the interface ID from IUnknown:

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -7,11 +7,11 @@
 use crate::ffi::*;
 use crate::os::{HRESULT, LPCWSTR, LPWSTR, WCHAR};
 use crate::utils::{from_wide, to_wide, HassleError};
-use com_rs::ComPtr;
 use libloading::{Library, Symbol};
 use std::ffi::c_void;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use tinycom::ComPtr;
 
 #[macro_export]
 macro_rules! check_hr {
@@ -140,18 +140,18 @@ pub trait DxcIncludeHandler {
 #[repr(C)]
 struct DxcIncludeHandlerWrapperVtbl {
     query_interface: extern "system" fn(
-        *const com_rs::IUnknown,
-        &com_rs::IID,
+        *const tinycom::IUnknown,
+        &tinycom::IID,
         *mut *mut core::ffi::c_void,
-    ) -> com_rs::HResult,
-    add_ref: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
-    release: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
+    ) -> tinycom::HResult,
+    add_ref: extern "system" fn(*const tinycom::IUnknown) -> HRESULT,
+    release: extern "system" fn(*const tinycom::IUnknown) -> HRESULT,
     #[cfg(not(windows))]
-    complete_object_destructor: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
+    complete_object_destructor: extern "system" fn(*const tinycom::IUnknown) -> HRESULT,
     #[cfg(not(windows))]
-    deleting_destructor: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
+    deleting_destructor: extern "system" fn(*const tinycom::IUnknown) -> HRESULT,
     load_source:
-        extern "system" fn(*mut com_rs::IUnknown, LPCWSTR, *mut *mut IDxcBlob) -> com_rs::HResult,
+        extern "system" fn(*mut tinycom::IUnknown, LPCWSTR, *mut *mut IDxcBlob) -> tinycom::HResult,
 }
 
 #[repr(C)]
@@ -164,22 +164,22 @@ struct DxcIncludeHandlerWrapper<'a> {
 
 impl<'a> DxcIncludeHandlerWrapper<'a> {
     extern "system" fn query_interface(
-        _me: *const com_rs::IUnknown,
-        _rrid: &com_rs::IID,
+        _me: *const tinycom::IUnknown,
+        _rrid: &tinycom::IID,
         _ppv_obj: *mut *mut core::ffi::c_void,
-    ) -> com_rs::HResult {
+    ) -> tinycom::HResult {
         0 // dummy impl
     }
 
-    extern "system" fn dummy(_me: *const com_rs::IUnknown) -> HRESULT {
+    extern "system" fn dummy(_me: *const tinycom::IUnknown) -> HRESULT {
         0 // dummy impl
     }
 
     extern "system" fn load_source(
-        me: *mut com_rs::IUnknown,
+        me: *mut tinycom::IUnknown,
         filename: LPCWSTR,
         include_source: *mut *mut IDxcBlob,
-    ) -> com_rs::HResult {
+    ) -> tinycom::HResult {
         let me = me as *mut DxcIncludeHandlerWrapper;
 
         let filename = crate::utils::from_wide(filename as *mut _);
@@ -520,7 +520,7 @@ fn dxcompiler_lib_name() -> &'static Path {
 
 #[cfg(target_os = "linux")]
 fn dxcompiler_lib_name() -> &'static Path {
-    Path::new("./libdxcompiler.so")
+    Path::new(".libdxcompiler.so")
 }
 
 #[cfg(target_os = "macos")]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -520,7 +520,7 @@ fn dxcompiler_lib_name() -> &'static Path {
 
 #[cfg(target_os = "linux")]
 fn dxcompiler_lib_name() -> &'static Path {
-    Path::new(".libdxcompiler.so")
+    Path::new("libdxcompiler.so")
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
I fixed a couple of issues in com-rs (wasn't really supposed to support linux, it broke when compiling with gcc code coverage reporting) and republished it under tinycom, that is going to be maintained by [Legion Labs](https://legionlabs.com/about), I can add this repo to the maintenance list, I though also about vendoring it directly in this repo, and I'm open to do so.
The other alternatives could be:
* https://github.com/microsoft/com-rs: Seems to target windows only
* https://github.com/Rantanen/intercom: Ability to write COM components in rust, which could be used, but it's a bit too big.

Also misc: changed the path of libdxcompiler.so on Linux. We test extensively on Linux, and it seems more sensible to have it global, I can split it in another PR if necessary.
