### PR TITLE
wrapper: Temporarily allow Rust 1.60 `clippy::ptr_arg` false-positive

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -195,7 +195,8 @@ impl DxcCompiler {
     fn prep_defines(
         defines: &[(&str, Option<&str>)],
         wide_defines: &mut Vec<(Vec<WCHAR>, Vec<WCHAR>)>,
-        dxc_defines: &mut Vec<DxcDefine>,
+        // Temporary false-positive in Rust 1.60, Vec::push() below isn't available on slices.
+        #[allow(clippy::ptr_arg)] dxc_defines: &mut Vec<DxcDefine>,
     ) {
         for (name, value) in defines {
             if value.is_none() {


### PR DESCRIPTION
This false-positive is already gone in the next (Rust 1.61) beta, but limiting our ability to accept contributions during the Rust 1.60 stable window.
