### PR TITLE
Breaking: Revert "[WIN/LINUX] Implement vtable dummies (virtual dtors) through extra trait"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Outside of Windows (e.g. Unix) the emulated COM API needed its fair share of fix
 
 | Since `hassle-rs` | DXC release | Git commit |
 |-|-|-|
-| Unreleased (0.10.0?) | Unreleased | https://github.com/microsoft/DirectXShaderCompiler/commit/47f31378a9b51894b0465b33ac1d10ce6349a468 |
-| 0.5.1 (if using `intellisense`) | release-1.6.2012 | https://github.com/microsoft/DirectXShaderCompiler/commit/2ade6f84d6b95bfd96eec1d6d15e3aa3b519d180 |
+| 0.10.0 | [v1.7.2212](https://github.com/microsoft/DirectXShaderCompiler/releases/tag/v1.7.2212) | https://github.com/microsoft/DirectXShaderCompiler/commit/47f31378a9b51894b0465b33ac1d10ce6349a468 |
+| 0.5.1 (if using `intellisense`) | [release-1.6.2012](https://github.com/microsoft/DirectXShaderCompiler/tree/release-1.6.2012) | https://github.com/microsoft/DirectXShaderCompiler/commit/2ade6f84d6b95bfd96eec1d6d15e3aa3b519d180 |
 
 When compiling on MacOS with `clang`, or Linux with `gcc`, be sure to have at least https://github.com/microsoft/DirectXShaderCompiler/commit/af14220b45d3ce46e0bad51ce79655e41d07c478 (also included in `release-1.6.2012`).
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,36 @@ Add this to your `Cargo.toml`:
 hassle-rs = "0.9.0"
 ```
 
-Then acquire `dxcompiler.dll` on Windows or `libdxcompiler.so` on Linux directly from [AppVeyor](https://ci.appveyor.com/project/antiagainst/directxshadercompiler/branch/master/artifacts), or compile it from source according to the instructions in the [DirectXShaderCompiler](https://github.com/Microsoft/DirectXShaderCompiler) GitHub repository and make sure it's in the executable environment.
+Then acquire `dxcompiler.dll` on Windows or `libdxcompiler.so` on Linux directly from [AppVeyor](https://ci.appveyor.com/project/antiagainst/directxshadercompiler/branch/master/artifacts), or compile it from source according to [the instructions](https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/DxcOnUnix.rst#building-dxc) in the [DirectXShaderCompiler](https://github.com/Microsoft/DirectXShaderCompiler) GitHub repository and make sure it's in the executable environment. See our [support table](##Supported-DXC-versions-on-non-Windows) below for specific compatibility notes on non-Windows OSes.
 
 DxcValidator also requires `dxil.dll` which can be grabbed from any recent Windows 10 SDK flight.
 More info: https://www.wihlidal.com/blog/pipeline/2018-09-16-dxil-signing-post-compile/
 
-## Compile HLSL into SPIR-V:
+## Supported DXC versions on non-Windows
+
+Outside of Windows (e.g. Unix) the emulated COM API needed its fair share of fixes to match the layout on Windows. This results in repetitive API breakage that is hard to detect from within `hassle-rs`: be sure to math the `hassle-rs` release below to a minimum DXC commit to prevent runtime failures outside of Windows!
+
+| Since `hassle-rs` | DXC release | Git commit |
+|-|-|-|
+| Unreleased (0.10.0?) | Unreleased | https://github.com/microsoft/DirectXShaderCompiler/commit/47f31378a9b51894b0465b33ac1d10ce6349a468 |
+| 0.5.1 (if using `intellisense`) | release-1.6.2012 | https://github.com/microsoft/DirectXShaderCompiler/commit/2ade6f84d6b95bfd96eec1d6d15e3aa3b519d180 |
+
+When compiling on MacOS with `clang`, or Linux with `gcc`, be sure to have at least https://github.com/microsoft/DirectXShaderCompiler/commit/af14220b45d3ce46e0bad51ce79655e41d07c478 (also included in `release-1.6.2012`).
+
+<details>
+<summary>Interesting DXC commits pertaining Unix support</summary>
+
+These patches have had an effect on `hassle-rs` compatibility over time:
+
+- [`[Linux] WinAdapter: Remove virtual dtors from IUnknown to fix vtable ABI`](https://github.com/microsoft/DirectXShaderCompiler/commit/47f31378a9b51894b0465b33ac1d10ce6349a468)
+- [`Linux: Implement prefix-counted BSTR allocation in SysAllocStringLen`](https://github.com/microsoft/DirectXShaderCompiler/commit/2ade6f84d6b95bfd96eec1d6d15e3aa3b519d180)
+- [`[linux-port] Support full IID comparison on GCC`](https://github.com/microsoft/DirectXShaderCompiler/commit/af14220b45d3ce46e0bad51ce79655e41d07c478)
+
+</details>
+
+## Usage examples
+
+### Compile HLSL into SPIR-V
 
 ```rust
 let spirv = compile_hlsl(
@@ -43,7 +67,7 @@ let spirv = compile_hlsl(
 );
 ```
 
-## Compile HLSL into DXIL and validate it:
+### Compile HLSL into DXIL and validate it
 
 ```rust
 let dxil = compile_hlsl("test.cs.hlsl", test_cs, "main", "cs_6_5", args, &[]).unwrap();
@@ -53,16 +77,6 @@ if let Some(err) = result.err() {
     println!("validation failed: {}", err);
 }
 ```
-
-## macOS support
-
-One can build `libdxcompiler.dynlib` from source with [this commit](https://github.com/microsoft/DirectXShaderCompiler/pull/3062/commits/9f2b30aa333f22eed00bf37b3a9b94f5ff5d23fe) for `clang` or [the entire PR](https://github.com/microsoft/DirectXShaderCompiler/pull/3062) for `GCC`, by following [the DXC Unix build guide](https://github.com/microsoft/DirectXShaderCompiler/blob/master/docs/DxcOnUnix.rst#building-dxc). These patches [have been merged](https://github.com/microsoft/DirectXShaderCompiler/commit/af14220b45d3ce46e0bad51ce79655e41d07c478) to DXC and are available since `release-1.6.2012`.
-
-## Linux support
-
-Linux shares the same requirements as [macOS support](#macOS-support) when compiling from source but DXC provides prebuilt libraries for every commit on [AppVeyor](https://ci.appveyor.com/project/dnovillo/directxshadercompiler/history). These are linked from individual commits on GitHub too.
-
-Furthermore semantics around `BSTR` (only used in `intellisense`) have [changed since hassle-rs 0.5.1](https://github.com/Traverse-Research/hassle-rs/commit/94670248cc01614c3a9c9f4d5288afb4040544bd) and require `libdxcompiler.so` compiled from at least [this commit](https://github.com/microsoft/DirectXShaderCompiler/commit/2ade6f84d6b95bfd96eec1d6d15e3aa3b519d180), also included in `release-1.6.2012`. `Intellisense` on hassle-rs `0.5.0` and below is not compatible with these newer libraries.
 
 ## License
 
@@ -74,6 +88,7 @@ Licensed under MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses
  - Tiago Carvalho
  - Marijn Suijten
  - Tomasz Stachowiak
+ - Manon Oomen
 
 ## Contribution
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::os::{HRESULT, LPCWSTR, LPWSTR};
-pub(crate) use crate::unknown::IDxcUnknownShim;
 use com_rs::{com_interface, iid, IUnknown, IID};
 use std::ffi::c_void;
 
@@ -20,7 +19,7 @@ pub const DFCC_DXIL: u32 = u32::from_le_bytes([b'D', b'X', b'I', b'L']);
 
 iid!(pub IID_IDxcBlob = 0x8BA5_FB08, 0x5195, 0x40e2, 0xAC, 0x58, 0x0D, 0x98, 0x9C, 0x3A, 0x01, 0x02);
 com_interface! {
-    interface IDxcBlob: IDxcUnknownShim, IUnknown {
+    interface IDxcBlob: IUnknown{
         iid: IID_IDxcBlob,
         vtable: IDxcBlobVtbl,
         fn get_buffer_pointer() -> *mut c_void;
@@ -30,7 +29,7 @@ com_interface! {
 
 iid!(pub IID_IDxcBlobEncoding = 0x7241_d424, 0x2646, 0x4191, 0x97, 0xc0, 0x98, 0xe9, 0x6e, 0x42, 0xfc, 0x68);
 com_interface! {
-    interface IDxcBlobEncoding: IDxcBlob, IDxcUnknownShim, IUnknown {
+    interface IDxcBlobEncoding: IDxcBlob, IUnknown{
         iid: IID_IDxcBlobEncoding,
         vtable: IDxcBlobEncodingVtbl,
         fn get_encoding(known: *mut u32, code_page: *mut u32) -> HRESULT;
@@ -39,7 +38,7 @@ com_interface! {
 
 iid!(pub IID_IDxcLibrary = 0xe520_4dc7, 0xd18c, 0x4c3c, 0xbd, 0xfb, 0x85, 0x16, 0x73, 0x98, 0x0f, 0xe7);
 com_interface! {
-    interface IDxcLibrary: IDxcUnknownShim, IUnknown {
+    interface IDxcLibrary: IUnknown{
         iid: IID_IDxcLibrary,
         vtable: IDxcLibraryVtbl,
         fn set_malloc(malloc: *const c_void) -> HRESULT;
@@ -57,7 +56,7 @@ com_interface! {
 
 iid!(pub IID_IDxcOperationResult = 0xCEDB_484A, 0xD4E9, 0x445A, 0xB9, 0x91, 0xCA, 0x21, 0xCA, 0x15, 0x7D, 0xC2);
 com_interface! {
-    interface IDxcOperationResult: IDxcUnknownShim, IUnknown {
+    interface IDxcOperationResult: IUnknown{
         iid: IID_IDxcOperationResult,
         vtable: IDxcOperationResultVtbl,
         fn get_status(status: *mut u32) -> HRESULT;
@@ -68,7 +67,7 @@ com_interface! {
 
 iid!(pub IID_IDxcIncludeHandler = 0x7f61_fc7d, 0x950d, 0x467f, 0xb3, 0xe3, 0x3c, 0x02, 0xfb, 0x49, 0x18, 0x7c);
 com_interface! {
-    interface IDxcIncludeHandler: IDxcUnknownShim, IUnknown {
+    interface IDxcIncludeHandler: IUnknown{
         iid: IID_IDxcIncludeHandler,
         vtable: IDxcIncludeHandlerVtbl,
         fn load_source(filename: LPCWSTR, include_source: *mut *mut IDxcBlob) -> HRESULT;
@@ -84,7 +83,7 @@ pub struct DxcDefine {
 
 iid!(pub IID_IDxcCompiler = 0x8c21_0bf3, 0x011f, 0x4422, 0x8d, 0x70, 0x6f, 0x9a, 0xcb, 0x8d, 0xb6, 0x17);
 com_interface! {
-    interface IDxcCompiler: IDxcUnknownShim, IUnknown {
+    interface IDxcCompiler: IUnknown{
         iid: IID_IDxcCompiler,
         vtable: IDxcCompilerVtbl,
         fn compile(
@@ -117,7 +116,7 @@ com_interface! {
 
 iid!(pub IID_IDxcCompiler2 = 0xA005_A9D9, 0xB8BB, 0x4594, 0xB5, 0xC9, 0x0E, 0x63, 0x3B, 0xEC, 0x4D, 0x37);
 com_interface! {
-    interface IDxcCompiler2: IDxcCompiler, IDxcUnknownShim, IUnknown {
+    interface IDxcCompiler2: IDxcCompiler, IUnknown{
         iid: IID_IDxcCompiler2,
         vtable: IDxcCompiler2Vtbl,
 
@@ -139,7 +138,7 @@ com_interface! {
 
 iid!(pub IID_IDxcLinker = 0xF1B5_BE2A, 0x62DD, 0x4327, 0xA1, 0xC2, 0x42, 0xAC, 0x1E, 0x1E, 0x78, 0xE6);
 com_interface! {
-    interface IDxcLinker: IDxcUnknownShim, IUnknown {
+    interface IDxcLinker: IUnknown{
         iid: IID_IDxcLinker,
         vtable: IDxcLinkerVtbl,
 
@@ -164,7 +163,7 @@ pub const DXC_VALIDATOR_FLAGS_VALID_MASK: u32 = 0x7;
 
 iid!(pub IID_IDxcValidator = 0xA6E8_2BD2, 0x1FD7, 0x4826, 0x98, 0x11, 0x28, 0x57, 0xE7, 0x97, 0xF4, 0x9A);
 com_interface! {
-    interface IDxcValidator: IDxcUnknownShim, IUnknown {
+    interface IDxcValidator: IUnknown{
         iid: IID_IDxcValidator,
         vtable: IDxcValidatorVtbl,
 
@@ -174,7 +173,7 @@ com_interface! {
 
 iid!(pub IID_IDxcContainerBuilder = 0x334b_1f50, 0x2292, 0x4b35, 0x99, 0xa1, 0x25, 0x58, 0x8d, 0x8c, 0x17, 0xfe);
 com_interface! {
-    interface IDxcContainerBuilder: IDxcUnknownShim, IUnknown {
+    interface IDxcContainerBuilder: IUnknown{
         iid: IID_IDxcContainerBuilder,
         vtable: IDxcContainerBuilderVtbl,
 
@@ -187,7 +186,7 @@ com_interface! {
 
 iid!(pub IID_IDxcAssembler = 0x091f_7a26, 0x1c1f, 0x4948, 0x90, 0x4b, 0xe6, 0xe3, 0xa8, 0xa7, 0x71, 0xd5);
 com_interface! {
-    interface IDxcAssembler: IDxcUnknownShim, IUnknown {
+    interface IDxcAssembler: IUnknown{
         iid: IID_IDxcAssembler,
         vtable: IDxcAssemblerVtbl,
 
@@ -197,7 +196,7 @@ com_interface! {
 
 iid!(pub IID_IDxcContainerReflection = 0xd2c2_1b26, 0x8350, 0x4bdc, 0x97, 0x6a, 0x33, 0x1c, 0xe6, 0xf4, 0xc5, 0x4c);
 com_interface! {
-    interface IDxcContainerReflection: IDxcUnknownShim, IUnknown {
+    interface IDxcContainerReflection: IUnknown{
         iid: IID_IDxcContainerReflection,
         vtable: IDxcContainerReflectionVtbl,
 
@@ -212,7 +211,7 @@ com_interface! {
 
 iid!(pub IID_IDxcOptimizerPass = 0xAE2C_D79F, 0xCC22, 0x453F, 0x9B, 0x6B, 0xB1, 0x24, 0xE7, 0xA5, 0x20, 0x4C);
 com_interface! {
-    interface IDxcOptimizerPass: IDxcUnknownShim, IUnknown {
+    interface IDxcOptimizerPass: IUnknown{
         iid: IID_IDxcOptimizerPass,
         vtable: IDxcOptimizerPassVtbl,
 
@@ -226,7 +225,7 @@ com_interface! {
 
 iid!(pub IID_IDxcOptimizer = 0x2574_0E2E, 0x9CBA, 0x401B, 0x91, 0x19, 0x4F, 0xB4, 0x2F, 0x39, 0xF2, 0x70);
 com_interface! {
-    interface IDxcOptimizer: IDxcUnknownShim, IUnknown {
+    interface IDxcOptimizer: IUnknown{
         iid: IID_IDxcOptimizer,
         vtable: IDxcOptimizerVtbl,
 
@@ -247,7 +246,7 @@ pub const DXC_VERSION_INFO_FLAGS_INTERNAL: u32 = 2; // Internal Validator (non-s
 
 iid!(pub IID_IDxcVersionInfo = 0xb04f_5b50, 0x2059, 0x4f12, 0xa8, 0xff, 0xa1, 0xe0, 0xcd, 0xe1, 0xcc, 0x7e);
 com_interface! {
-    interface IDxcVersionInfo: IDxcUnknownShim, IUnknown {
+    interface IDxcVersionInfo: IUnknown{
         iid: IID_IDxcVersionInfo,
         vtable: IDxcVersionInfoVtbl,
 
@@ -258,7 +257,7 @@ com_interface! {
 
 iid!(pub IID_IDxcVersionInfo2 = 0xfb69_04c4, 0x42f0, 0x4b62, 0x9c, 0x46, 0x98, 0x3a, 0xf7, 0xda, 0x7c, 0x83);
 com_interface! {
-    interface IDxcVersionInfo2: IDxcUnknownShim, IUnknown {
+    interface IDxcVersionInfo2: IUnknown{
         iid: IID_IDxcVersionInfo2,
         vtable: IDxcVersionInfo2Vtbl,
 

--- a/src/intellisense/ffi.rs
+++ b/src/intellisense/ffi.rs
@@ -1,5 +1,4 @@
 use crate::os::{BSTR, HRESULT, LPCSTR, LPSTR};
-pub(crate) use crate::unknown::IDxcUnknownShim;
 use bitflags::bitflags;
 use com_rs::{com_interface, iid, IUnknown};
 
@@ -359,7 +358,7 @@ bitflags! {
 
 iid!(pub IID_IDxcDiagnostic = 0x4f76b234, 0x3659, 0x4d33, 0x99, 0xb0, 0x3b, 0x0d, 0xb9, 0x94, 0xb5, 0x64);
 com_interface! {
-    interface IDxcDiagnostic: IDxcUnknownShim, IUnknown {
+    interface IDxcDiagnostic: IUnknown{
         iid: IID_IDxcDiagnostic,
         vtable: IDxcDiagnosticVtbl,
         fn format_diagnostic(options: DxcDiagnosticDisplayOptions, result: *mut LPSTR) -> HRESULT;
@@ -376,7 +375,7 @@ com_interface! {
 
 iid!(pub IID_IDxcInclusion = 0x0c364d65, 0xdf44, 0x4412, 0x88, 0x8e, 0x4e, 0x55, 0x2f, 0xc5, 0xe3, 0xd6);
 com_interface! {
-    interface IDxcInclusion: IDxcUnknownShim, IUnknown {
+    interface IDxcInclusion: IUnknown{
         iid: IID_IDxcInclusion,
         vtable: IDxcInclusionVtbl,
         fn get_included_file(result: *mut *mut IDxcFile) -> HRESULT;
@@ -387,7 +386,7 @@ com_interface! {
 
 iid!(pub IID_IDxcToken = 0x7f90b9ff, 0xa275, 0x4932, 0x97, 0xd8, 0x3c, 0xfd, 0x23, 0x44, 0x82, 0xa2);
 com_interface! {
-    interface IDxcToken: IDxcUnknownShim, IUnknown {
+    interface IDxcToken: IUnknown{
         iid: IID_IDxcToken,
         vtable: IDxcTokenVtbl,
         fn get_kind(value: *mut DxcTokenKind) -> HRESULT;
@@ -399,7 +398,7 @@ com_interface! {
 
 iid!(pub IID_IDxcType = 0x2ec912fd, 0xb144, 0x4a15, 0xad, 0x0d, 0x1c, 0x54, 0x39, 0xc8, 0x1e, 0x46);
 com_interface! {
-    interface IDxcType: IDxcUnknownShim, IUnknown {
+    interface IDxcType: IUnknown{
         iid: IID_IDxcType,
         vtable: IDxcTypeVtbl,
         fn get_spelling(result: *mut LPSTR) -> HRESULT;
@@ -410,7 +409,7 @@ com_interface! {
 
 iid!(pub IID_IDxcSourceLocation = 0x8e7ddf1c, 0xd7d3, 0x4d69, 0xb2, 0x86, 0x85, 0xfc, 0xcb, 0xa1, 0xe0, 0xcf);
 com_interface! {
-    interface IDxcSourceLocation: IDxcUnknownShim, IUnknown {
+    interface IDxcSourceLocation: IUnknown{
         iid: IID_IDxcSourceLocation,
         vtable: IDxcSourceLocationVtbl,
         fn is_equal_to(other: *const IDxcSourceLocation, result: *mut bool) -> HRESULT;
@@ -421,7 +420,7 @@ com_interface! {
 
 iid!(pub IID_IDxcSourceRange = 0xf1359b36, 0xa53f, 0x4e81, 0xb5, 0x14, 0xb6, 0xb8, 0x41, 0x22, 0xa1, 0x3f);
 com_interface! {
-    interface IDxcSourceRange: IDxcUnknownShim, IUnknown {
+    interface IDxcSourceRange: IUnknown{
         iid: IID_IDxcSourceRange,
         vtable: IDxcSourceRangeVtbl,
         fn is_null(value: *mut bool) -> HRESULT;
@@ -433,7 +432,7 @@ com_interface! {
 
 iid!(pub IID_IDxcCursor = 0x1467b985, 0x288d, 0x4d2a, 0x80, 0xc1, 0xef, 0x89, 0xc4, 0x2c, 0x40, 0xbc);
 com_interface! {
-    interface IDxcCursor: IDxcUnknownShim, IUnknown {
+    interface IDxcCursor: IUnknown{
         iid: IID_IDxcCursor,
         vtable: IDxcCursorVtbl,
         fn get_extent(range: *mut *mut IDxcSourceRange) -> HRESULT;
@@ -462,7 +461,7 @@ com_interface! {
 
 iid!(pub IID_IDxcUnsavedFile = 0x8ec00f98, 0x07d0, 0x4e60, 0x9d, 0x7c, 0x5a, 0x50, 0xb5, 0xb0, 0x01, 0x7f);
 com_interface! {
-    interface IDxcUnsavedFile: IDxcUnknownShim, IUnknown {
+    interface IDxcUnsavedFile: IUnknown{
         iid: IID_IDxcUnsavedFile,
         vtable: IDxcUnsavedFileVtbl,
         fn get_file_name(file_name: *mut LPSTR) -> HRESULT;
@@ -473,7 +472,7 @@ com_interface! {
 
 iid!(pub IID_IDxcFile = 0xbb2fca9e, 0x1478, 0x47ba, 0xb0, 0x8c, 0x2c, 0x50, 0x2a, 0xda, 0x48, 0x95);
 com_interface! {
-    interface IDxcFile: IDxcUnknownShim, IUnknown {
+    interface IDxcFile: IUnknown{
         iid: IID_IDxcFile,
         vtable: IDxcFileVtbl,
         fn get_name(result: *mut LPSTR) -> HRESULT;
@@ -483,7 +482,7 @@ com_interface! {
 
 iid!(pub IID_IDxcTranslationUnit = 0x9677dee0, 0xc0e5, 0x46a1, 0x8b, 0x40, 0x3d, 0xb3, 0x16, 0x8b, 0xe6, 0x3d);
 com_interface! {
-    interface IDxcTranslationUnit: IDxcUnknownShim, IUnknown {
+    interface IDxcTranslationUnit: IUnknown{
         iid: IID_IDxcTranslationUnit,
         vtable: IDxcTranslationUnitVtbl,
         fn get_cursor(cursor: *mut *mut IDxcCursor) -> HRESULT;
@@ -506,7 +505,7 @@ com_interface! {
 
 iid!(pub IID_IDxcIndex = 0x937824a0, 0x7f5a, 0x4815, 0x9b, 0xa, 0x7c, 0xc0, 0x42, 0x4f, 0x41, 0x73);
 com_interface! {
-    interface IDxcIndex: IDxcUnknownShim, IUnknown {
+    interface IDxcIndex: IUnknown{
         iid: IID_IDxcIndex,
         vtable: IDxcIndexVtbl,
         fn set_global_options(options: DxcGlobalOptions) -> HRESULT;
@@ -524,7 +523,7 @@ com_interface! {
 
 iid!(pub IID_IDxcIntelliSense = 0xb1f99513, 0x46d6, 0x4112, 0x81, 0x69, 0xdd, 0x0d, 0x60, 0x53, 0xf1, 0x7d);
 com_interface! {
-    interface IDxcIntelliSense: IDxcUnknownShim, IUnknown {
+    interface IDxcIntelliSense: IUnknown{
         iid: IID_IDxcIntelliSense,
         vtable: IDxcIntelliSenseVtbl,
         fn create_index(index: *mut *mut IDxcIndex) -> HRESULT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@
 //! );
 //! ```
 
-pub(crate) mod unknown;
-
 pub mod fake_sign;
 pub mod ffi;
 pub mod os;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -119,10 +119,6 @@ struct DxcIncludeHandlerWrapperVtbl {
     ) -> HRESULT,
     add_ref: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
     release: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
-    #[cfg(not(windows))]
-    complete_object_destructor: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
-    #[cfg(not(windows))]
-    deleting_destructor: extern "system" fn(*const com_rs::IUnknown) -> HRESULT,
     load_source: extern "system" fn(*mut com_rs::IUnknown, LPCWSTR, *mut *mut IDxcBlob) -> HRESULT,
 }
 
@@ -143,7 +139,11 @@ impl<'a, 'i> DxcIncludeHandlerWrapper<'a, 'i> {
         HRESULT(0) // dummy impl
     }
 
-    extern "system" fn dummy(_me: *const com_rs::IUnknown) -> HRESULT {
+    extern "system" fn add_ref(_me: *const com_rs::IUnknown) -> HRESULT {
+        HRESULT(0) // dummy impl
+    }
+
+    extern "system" fn release(_me: *const com_rs::IUnknown) -> HRESULT {
         HRESULT(0) // dummy impl
     }
 
@@ -230,12 +230,8 @@ impl DxcCompiler {
         if let Some(include_handler) = include_handler {
             let vtable = DxcIncludeHandlerWrapperVtbl {
                 query_interface: DxcIncludeHandlerWrapper::query_interface,
-                add_ref: DxcIncludeHandlerWrapper::dummy,
-                release: DxcIncludeHandlerWrapper::dummy,
-                #[cfg(not(windows))]
-                complete_object_destructor: DxcIncludeHandlerWrapper::dummy,
-                #[cfg(not(windows))]
-                deleting_destructor: DxcIncludeHandlerWrapper::dummy,
+                add_ref: DxcIncludeHandlerWrapper::add_ref,
+                release: DxcIncludeHandlerWrapper::release,
                 load_source: DxcIncludeHandlerWrapper::load_source,
             };
 


### PR DESCRIPTION
This reverts commit c37cb037be072cac43f2706b89f1388b9deee19a. [This commit] is squashed in the merge of PR #5, and does not exist in-tree.

https://github.com/microsoft/DirectXShaderCompiler/pull/3793 has finally been merged on October 13th 2022 and now allows us to drop the vtable dummies for virtual destructors again, as those are not part of the ABI and shouldn't have been in the vtable in the first place.

[This commit]: https://github.com/Traverse-Research/hassle-rs/pull/5/commits/c37cb037be072cac43f2706b89f1388b9deee19a

---

Note that releasing `hassle-rs` with this change relies on a DXC built with at least that PR, which was meged on October 13th.
