### PR TITLE
Include MIT `LICENSE` file in packaged release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/Traverse-Research/hassle-rs"
 repository = "https://github.com/Traverse-Research/hassle-rs"
 keywords = ["shader", "pipeline", "hlsl", "dxc", "intellisense"]
 categories = ["rendering", "rendering::graphics-api"]
-include = ["src"]
+include = ["src", "LICENSE"]
 documentation = "https://docs.rs/hassle-rs"
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,7 @@ homepage = "https://github.com/Traverse-Research/hassle-rs"
 repository = "https://github.com/Traverse-Research/hassle-rs"
 keywords = ["shader", "pipeline", "hlsl", "dxc", "intellisense"]
 categories = ["rendering", "rendering::graphics-api"]
-include = [
-    "src/*.rs",
-    "src/intellisense/*.rs",
-    "src/fake_sign/*.rs",
-    "Cargo.toml",
-]
+include = ["src"]
 documentation = "https://docs.rs/hassle-rs"
 
 [badges]


### PR DESCRIPTION
- cargo: Simplify `include` list
- Include MIT `LICENSE` file in release
- Release 0.10.0
