### PR TITLE
Allow `libloading` v0.7 and v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ documentation = "https://docs.rs/hassle-rs"
 [dependencies]
 bitflags = "2"
 com = { version = "0.6", features = ["production"] }
-libloading = "0.8"
+# libloading 0.8 switches from `winapi` to `windows-sys`; permit either
+libloading = ">=0.7,<0.9"
 thiserror = "1.0.2"
 widestring = "1"
 


### PR DESCRIPTION
The only relevant change in v0.8 is the migration to `windows-sys`: https://docs.rs/libloading/0.8.0/libloading/changelog/r0_8_0/index.html.

This is done in the same spirit as https://github.com/gfx-rs/wgpu/pull/3711 because I heard Mozilla, who is using `wgpu`, isn't ready to migrate to `windows-sys` yet, see https://github.com/gfx-rs/wgpu/issues/3207.

`d3d12` did this as well: https://github.com/gfx-rs/d3d12-rs/pull/43.

Originally coming from here: https://github.com/Traverse-Research/hassle-rs/pull/67#discussion_r1222169498.