### PR TITLE
🔗 Expose the Dxc linker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ libc = "0.2"
 
 [dev-dependencies]
 rspirv = "0.11"
+spirv-linker = "0.1"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,7 @@ pub(crate) fn from_lpstr(string: LPCSTR) -> String {
         .to_owned()
 }
 
-struct DefaultIncludeHandler {}
+pub struct DefaultIncludeHandler {}
 
 impl DxcIncludeHandler for DefaultIncludeHandler {
     fn load_source(&mut self, filename: String) -> Option<String> {


### PR DESCRIPTION
Alright so this needs a bit of work still, but I'm happy to be where we are.

1. DXC and now this library allow for linking DXIL
2. I've released `spirv-linker` to link spirv binaries

Unfortunately, `dxc` doesn't compile `use-export.hlsl` properly when compiled for spirv. The compiler doesn't output any sensible ops for the shader, and as a result, actually linking anything for spirv can't quite be done at the moment.