### PR TITLE
utils: Provide `OperationOutput` wrapper to parse `DxcOperationResult`

### DIFF
--- a/examples/include.rs
+++ b/examples/include.rs
@@ -5,12 +5,16 @@ use rspirv::dr::load_bytes;
 fn main() {
     let source = include_str!("include.hlsl");
 
-    match compile_hlsl("include.hlsl", source, "copyCs", "cs_6_0", &["-spirv"], &[]) {
-        Ok(spirv) => {
-            let module = load_bytes(spirv).unwrap();
-            println!("{}", module.disassemble());
+    let spirv = match compile_hlsl("include.hlsl", source, "copyCs", "cs_6_0", &["-spirv"], &[]) {
+        Ok(OperationOutput { messages, blob }) => {
+            if let Some(m) = messages {
+                eprintln!("Compiled to SPIR-V with warnings:\n{m}");
+            }
+            blob
         }
         // Could very well happen that one needs to recompile or download a dxcompiler.dll
-        Err(s) => panic!("Failed to compile to SPIR-V: {}", s),
-    }
+        Err(e) => panic!("Failed to compile to SPIR-V: {:?}", e),
+    };
+    let module = load_bytes(spirv).unwrap();
+    println!("{}", module.disassemble());
 }

--- a/examples/spirv.rs
+++ b/examples/spirv.rs
@@ -5,12 +5,16 @@ use rspirv::dr::load_bytes;
 fn main() {
     let source = include_str!("copy.hlsl");
 
-    match compile_hlsl("copy.hlsl", source, "copyCs", "cs_6_0", &["-spirv"], &[]) {
-        Ok(spirv) => {
-            let module = load_bytes(spirv).unwrap();
-            println!("{}", module.disassemble());
+    let spirv = match compile_hlsl("copy.hlsl", source, "copyCs", "cs_6_0", &["-spirv"], &[]) {
+        Ok(OperationOutput { messages, blob }) => {
+            if let Some(m) = messages {
+                eprintln!("Compiled to SPIR-V with warnings:\n{m}");
+            }
+            blob
         }
         // Could very well happen that one needs to recompile or download a dxcompiler.dll
-        Err(s) => panic!("Failed to compile to SPIR-V: {}", s),
-    }
+        Err(e) => panic!("Failed to compile to SPIR-V: {:?}", e),
+    };
+    let module = load_bytes(spirv).unwrap();
+    println!("{}", module.disassemble());
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,6 +5,12 @@ use crate::os::{HRESULT, LPCWSTR, LPWSTR};
 use com::{interfaces, interfaces::IUnknown, IID};
 use std::ffi::c_void;
 
+// https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+/// System ANSI codepage
+pub const CP_ACP: u32 = 0;
+/// Unicode (UTF-8)
+pub const CP_UTF8: u32 = 65001;
+
 pub type DxcCreateInstanceProc<T> =
     extern "system" fn(rclsid: &IID, riid: &IID, ppv: *mut Option<T>) -> HRESULT;
 
@@ -90,7 +96,7 @@ interfaces! {
 
     #[uuid("cedb484a-d4e9-445a-b991-ca21ca157dc2")]
     pub(crate) unsafe interface IDxcOperationResult: IUnknown {
-        pub(crate) fn get_status(&self, status: *mut u32) -> HRESULT;
+        pub(crate) fn get_status(&self, status: *mut i32) -> HRESULT;
         pub(crate) fn get_result(&self, result: *mut Option<IDxcBlob>) -> HRESULT;
         pub(crate) fn get_error_buffer(&self, errors: *mut Option<IDxcBlobEncoding>) -> HRESULT;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,5 +47,7 @@ pub mod wrapper;
 pub mod intellisense;
 
 pub use crate::ffi::*;
-pub use crate::utils::{compile_hlsl, fake_sign_dxil_in_place, validate_dxil, HassleError, Result};
+pub use crate::utils::{
+    compile_hlsl, fake_sign_dxil_in_place, validate_dxil, HassleError, OperationOutput, Result,
+};
 pub use crate::wrapper::*;

--- a/src/os.rs
+++ b/src/os.rs
@@ -106,16 +106,16 @@ impl std::fmt::Debug for HRESULT {
 
 impl std::fmt::Display for HRESULT {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("{:#x}", self))
+        write!(f, "{:#x}", self)
     }
 }
 
 impl std::fmt::LowerHex for HRESULT {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let prefix = if f.alternate() { "0x" } else { "" };
-        let bare_hex = format!("{:x}", self.0.abs());
+        let bare_hex = format!("{:x}", self.0 as u32);
         // https://stackoverflow.com/a/44712309
-        f.pad_integral(self.0 >= 0, prefix, &bare_hex)
+        f.pad_integral(false, prefix, &bare_hex)
         // <i32 as std::fmt::LowerHex>::fmt(&self.0, f)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -133,7 +133,7 @@ pub fn compile_hlsl(
         Err(result) => {
             let error_blob = result.0.get_error_buffer()?;
             Err(HassleError::CompileError(
-                library.get_blob_as_string(&error_blob.into())?,
+                library.get_blob_as_string(&error_blob)?,
             ))
         }
         Ok(result) => {
@@ -163,7 +163,7 @@ pub fn validate_dxil(data: &[u8]) -> Result<Vec<u8>, HassleError> {
         Err(result) => {
             let error_blob = result.0.get_error_buffer()?;
             Err(HassleError::ValidationError(
-                library.get_blob_as_string(&error_blob.into())?,
+                library.get_blob_as_string(&error_blob)?,
             ))
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,14 +51,13 @@ impl DxcIncludeHandler for DefaultIncludeHandler {
     }
 }
 
+/// Low-level library errors and high-level compilation errors.
 #[derive(Error, Debug)]
 pub enum HassleError {
+    #[error("Dxc error {0:x}: {0}")]
+    OperationError(HRESULT, String),
     #[error("Win32 error: {0:x}")]
     Win32Error(HRESULT),
-    #[error("{0}")]
-    CompileError(String),
-    #[error("Validation error: {0}")]
-    ValidationError(String),
     #[error("Failed to load library {filename:?}: {inner:?}")]
     LoadLibraryError {
         filename: PathBuf,
@@ -97,6 +96,47 @@ impl HRESULT {
     }
 }
 
+/// Wraps a successful output with optional compiler warnings/messages from [`DxcOperationResult`].
+/// Create with [`Self::from_operation_result()`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OperationOutput {
+    /// Messages ("error buffer") from DXC, typically contains warnings emitted while compiling or
+    /// validating shaders.
+    pub messages: Option<String>,
+    /// The resulting blob (typically a compiled or validated shader from [`compile_hlsl()`] or
+    /// [`validate_dxil()`]).
+    pub blob: Vec<u8>,
+}
+
+impl OperationOutput {
+    /// Helper to process [`DxcOperationResult`].
+    pub fn from_operation_result(result: DxcOperationResult) -> Result<Self> {
+        // Result blobs are always available, they might just be empty (length == 0) if there's no
+        // relevant data in them.
+        let error = result.get_error_buffer()?;
+        let error = error.as_str().expect("UTF-8 blob");
+
+        let output = result.get_result()?;
+
+        let status = result.get_status()?;
+
+        if status.is_err() {
+            assert!(output.as_ref().is_empty());
+            Err(HassleError::OperationError(status, error.to_owned()))
+        } else {
+            assert!(!output.as_ref().is_empty());
+            Ok(OperationOutput {
+                messages: if error.is_empty() {
+                    None
+                } else {
+                    Some(error.to_owned())
+                },
+                blob: output.to_vec(),
+            })
+        }
+    }
+}
+
 /// Helper function to directly compile a HLSL shader to an intermediate language,
 /// this function expects `dxcompiler.dll` to be available in the current
 /// executable environment.
@@ -111,7 +151,7 @@ pub fn compile_hlsl(
     target_profile: &str,
     args: &[&str],
     defines: &[(&str, Option<&str>)],
-) -> Result<Vec<u8>> {
+) -> Result<OperationOutput> {
     let dxc = Dxc::new(None)?;
 
     let compiler = dxc.create_compiler()?;
@@ -127,21 +167,9 @@ pub fn compile_hlsl(
         args,
         Some(&mut DefaultIncludeHandler {}),
         defines,
-    );
+    )?;
 
-    match result {
-        Err(result) => {
-            let error_blob = result.0.get_error_buffer()?;
-            Err(HassleError::CompileError(
-                library.get_blob_as_string(&error_blob)?,
-            ))
-        }
-        Ok(result) => {
-            let result_blob = result.get_result()?;
-
-            Ok(result_blob.to_vec())
-        }
-    }
+    OperationOutput::from_operation_result(result)
 }
 
 /// Helper function to validate a DXIL binary independent from the compilation process,
@@ -149,7 +177,7 @@ pub fn compile_hlsl(
 /// execution environment.
 ///
 /// `dxil.dll` is only available on Windows.
-pub fn validate_dxil(data: &[u8]) -> Result<Vec<u8>, HassleError> {
+pub fn validate_dxil(data: &[u8]) -> Result<OperationOutput> {
     let dxc = Dxc::new(None)?;
     let dxil = Dxil::new(None)?;
 
@@ -158,15 +186,9 @@ pub fn validate_dxil(data: &[u8]) -> Result<Vec<u8>, HassleError> {
 
     let blob_encoding = library.create_blob_with_encoding(data)?;
 
-    match validator.validate(blob_encoding.into()) {
-        Ok(blob) => Ok(blob.to_vec()),
-        Err(result) => {
-            let error_blob = result.0.get_error_buffer()?;
-            Err(HassleError::ValidationError(
-                library.get_blob_as_string(&error_blob)?,
-            ))
-        }
-    }
+    let result = validator.validate(&blob_encoding)?;
+
+    OperationOutput::from_operation_result(result)
 }
 
 pub use crate::fake_sign::fake_sign_dxil_in_place;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -24,20 +24,30 @@ impl DxcBlob {
     }
 
     pub fn as_slice<T>(&self) -> &[T] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.inner.get_buffer_pointer().cast(),
-                self.inner.get_buffer_size() / std::mem::size_of::<T>(),
-            )
+        let bytes = unsafe { self.inner.get_buffer_size() };
+        if bytes == 0 {
+            &[]
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(
+                    self.inner.get_buffer_pointer().cast(),
+                    bytes / size_of::<T>(),
+                )
+            }
         }
     }
 
     pub fn as_mut_slice<T>(&mut self) -> &mut [T] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.inner.get_buffer_pointer().cast(),
-                self.inner.get_buffer_size() / std::mem::size_of::<T>(),
-            )
+        let bytes = unsafe { self.inner.get_buffer_size() };
+        if bytes == 0 {
+            &mut []
+        } else {
+            unsafe {
+                std::slice::from_raw_parts_mut(
+                    self.inner.get_buffer_pointer().cast(),
+                    bytes / size_of::<T>(),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
> [!TIP]
> This patch started 5 years ago when I was still learning Rust and not confident in how to best represent this complicated result status. I think I've found a convenient way now (that doesn't hide the available API too much) and finally got around to push this out.

Thus far `hassle-rs` has made it possible - but not very convenient - to extract warnings/errors from a `DxcOperationResult` together with an optional successful result-blob.  This was always eaten up by our high-level `utils` wrappers however, giving you either errors on failure or only the result blob on success, but never the warnings.  This was always only available when manually calling the high level `ffi` `wrapper`, with the same inconvenience that `utils` has.

There's barely any upstream documentation, but through experimentation we see that both the output and error blobs are always returned, and `get_status()` is the definitive answer on whether the compilation was successful.  In either case, warnings/errors are available in the error buffer if its of non-zero length.

Thus we improve `HassleError` to contain the error string next to the (typically `E_FAIL`) `HRESULT`, leaving the new `OperationOutput` to contain the blob and all optional warnings/messages.

This parsing is still optional when using the `wrapper` API, but easy to call by downstream crates if they wish to simplify their handling into a `match` statement.  The `utils` wrappers return this type directly, incurring a little bit of "allocation overhead" for copying the underlying data into `Vec`s.

Note that this behaviour relies on previous patches fixing our UB `as_slice()` implementations to no longer construct (empty!) slices from NULL pointers.