### PR TITLE
Add DXIL support to Linux, allow searching for dxc/dxil on path/LD_LIBRARY_PATH if unspecified

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -520,7 +520,7 @@ impl Dxc {
         } else {
             #[cfg(target_os = "windows")]
             {
-                PathBuf::from_str(dxcompiler_lib_name())
+                PathBuf::from_str(dxcompiler_lib_name()).unwrap()
             }
             #[cfg(not(target_os = "windows"))]
             {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -520,7 +520,7 @@ impl Dxc {
         } else {
             #[cfg(target_os = "windows")]
             {
-                dxcompiler_lib_name().to_owned()
+                PathBuf::from_str(dxcompiler_lib_name())
             }
             #[cfg(not(target_os = "windows"))]
             {


### PR DESCRIPTION
Not sure if this PR is what is wanted upstream, but I found these changes useful. Leaving this PR here in case you guys do too.

Brief summary:
Previously, DXIL didn’t work on Linux even though the GitHub releases for DXC have contained a libdxil.so for a while now, I removed this blocker.
Previously, you had to provide a path to the DXC library, I have made this optional so that it will automatically search for the library.

Notes:
* Some old code has been commented out. That should probably be deleted instead if this PR is to be merged.
* Even though this should be a draft, I am marking it as a standard pull request so you folks might be more likely to see it. Feel free to close it or ask me to mark it as a draft.