### PR TITLE
Allow DXIL to be used outside of Windows as well

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -67,8 +67,6 @@ pub enum HassleError {
     },
     #[error("LibLoading error: {0:?}")]
     LibLoadingError(#[from] libloading::Error),
-    #[error("Windows only")]
-    WindowsOnly(String),
 }
 
 pub type Result<T, E = HassleError> = std::result::Result<T, E>;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -649,16 +649,8 @@ pub struct Dxil {
 }
 
 impl Dxil {
-    #[cfg(not(windows))]
-    pub fn new(_: Option<PathBuf>) -> Result<Self> {
-        Err(HassleError::WindowsOnly(
-            "DXIL Signing is only supported on Windows".to_string(),
-        ))
-    }
-
     /// `lib_path` is an optional path to the library.  Otherwise
     /// [`libloading::library_filename("dxil")`] is used.
-    #[cfg(windows)]
     pub fn new(lib_path: Option<PathBuf>) -> Result<Self> {
         let lib_path = lib_path.unwrap_or_else(|| PathBuf::from(library_filename("dxil")));
 


### PR DESCRIPTION
Depends on #74. Based on conversation from #81.

Microsoft is providing `libdxil.so` for Linux for a while (and since [open-sourcing it](https://devblogs.microsoft.com/directx/open-sourcing-dxil-validator-hash/), users are able to compile `libdxil.dylib` for Mac as well). Allow `hassle-rs` to use it on every platform by removing the now-unnecessary `#[cfg(windows)]`.