### PR TITLE
Fix missing error log in `HassleError::OperationError` `Display` format

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ impl DxcIncludeHandler for DefaultIncludeHandler {
 /// Low-level library errors and high-level compilation errors.
 #[derive(Error, Debug)]
 pub enum HassleError {
-    #[error("Dxc error {0:x}: {0}")]
+    #[error("Dxc error {0}: {1}")]
     OperationError(HRESULT, String),
     #[error("Win32 error: {0:x}")]
     Win32Error(HRESULT),


### PR DESCRIPTION
When just running with the latest error changes from PR #80, I was wondering why my error messages were disappearing but the `HRESULT` was printed twice (this is on runs with `-WX` to treat warnings as errors). Turns out I typo'd the `thiserror` format string to print the `HRESULT` in the second place as well rather than the error blob, resulting in: `Dxc error -80004005: -0x80004005`.  Replacing that with `{1}` gives the expected warning/error text from shader compilation again.
