### PR TITLE
os: Fix "double negation" in `HRESULT` hexadecimal formatting

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -106,16 +106,6 @@ impl std::fmt::Debug for HRESULT {
 
 impl std::fmt::Display for HRESULT {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#x}", self)
-    }
-}
-
-impl std::fmt::LowerHex for HRESULT {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let prefix = if f.alternate() { "0x" } else { "" };
-        let bare_hex = format!("{:x}", self.0 as u32);
-        // https://stackoverflow.com/a/44712309
-        f.pad_integral(false, prefix, &bare_hex)
-        // <i32 as std::fmt::LowerHex>::fmt(&self.0, f)
+        write!(f, "{:#x}", self.0)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,7 +56,7 @@ impl DxcIncludeHandler for DefaultIncludeHandler {
 pub enum HassleError {
     #[error("Dxc error {0}: {1}")]
     OperationError(HRESULT, String),
-    #[error("Win32 error: {0:x}")]
+    #[error("Win32 error: {0}")]
     Win32Error(HRESULT),
     #[error("Failed to load library {filename:?}: {inner:?}")]
     LoadLibraryError {


### PR DESCRIPTION
We typically see errors formatted as `-0x80004005`, because we tell `pad_integral()` that the number is negative while we format-printed it as **unsigned** integer which cannot be negative as represented by the highest `0x80000000` bit being set - appearing as a double negation of sorts?  Either we remove the misleading `-` or print the number as integer with the sign bit removed (which makes it harder to look up online).

The end result is that we can and should just remove this strange override of `LowerHex`, and rely purely on our `Display` implementation of `HRESULT` that format-prints the inner `i32` as hexadecimal with `0x` prefix, which automatically prints it as unsigned.

The end result is that we found one more case where `{:#x}` was overridden to just `{:x}` because `LowerHex` is no longer implemented for `HRESULT`, which was accidentally dropping the `0x` prefix in the format string too.
