### PR TITLE
wrapper: Add DxcLinker for IDxcLinker

### DIFF
--- a/examples/link-add.hlsl
+++ b/examples/link-add.hlsl
@@ -1,0 +1,5 @@
+// Library: exports a small helper.
+export float4 add4(float4 a, float4 b)
+{
+    return a + b;
+}

--- a/examples/link-main.hlsl
+++ b/examples/link-main.hlsl
@@ -1,0 +1,11 @@
+// Library: imports add4 from the other library and provides a compute entry point.
+float4 add4(float4 a, float4 b);
+
+RWStructuredBuffer<float4> output : register(u0);
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main()
+{
+    output[0] = add4(float4(1.0, 2.0, 3.0, 4.0), float4(10.0, 20.0, 30.0, 40.0));
+}

--- a/examples/link.rs
+++ b/examples/link.rs
@@ -1,0 +1,76 @@
+//! Compile two HLSL sources to `lib_6_8` DXIL libraries, register them with
+//! [`DxcLinker`], and link them into a single `cs_6_8` shader binary.
+
+use hassle_rs::wrapper::{Dxc, DxcIncludeHandler};
+use hassle_rs::OperationOutput;
+
+struct NoopIncludes;
+impl DxcIncludeHandler for NoopIncludes {
+    fn load_source(&mut self, _filename: String) -> Option<String> {
+        None
+    }
+}
+
+fn compile_lib(dxc: &Dxc, name: &str, source: &str) -> Vec<u8> {
+    let compiler = dxc.create_compiler().unwrap();
+    let library = dxc.create_library().unwrap();
+    let blob = library.create_blob_with_encoding_from_str(source).unwrap();
+
+    let result = compiler
+        .compile(
+            &blob,
+            name,
+            "", // entry-point ignored for lib targets
+            "lib_6_8",
+            &["-HV", "2021"],
+            Some(&mut NoopIncludes),
+            &[],
+        )
+        .expect("compile call");
+
+    let OperationOutput { messages, blob } =
+        OperationOutput::from_operation_result(result).expect("compile success");
+    if let Some(m) = messages {
+        eprintln!("[{name}] compile messages:\n{m}");
+    }
+    blob
+}
+
+fn main() {
+    let dxc = Dxc::new(None).expect("load dxcompiler");
+    let library = dxc.create_library().unwrap();
+
+    // Compile each source to a DXIL library blob.
+    let add_dxil = compile_lib(&dxc, "link-add.hlsl", include_str!("link-add.hlsl"));
+    let main_dxil = compile_lib(&dxc, "link-main.hlsl", include_str!("link-main.hlsl"));
+
+    // Wrap as DxcBlobs.
+    let add_blob = library.create_blob_with_encoding(&add_dxil).unwrap();
+    let main_blob = library.create_blob_with_encoding(&main_dxil).unwrap();
+
+    // Register and link.
+    let linker = dxc.create_linker().expect("create linker");
+    linker
+        .register_library("add", &add_blob)
+        .expect("register add");
+    linker
+        .register_library("main", &main_blob)
+        .expect("register main");
+
+    let result = linker
+        .link("main", "cs_6_8", &["add", "main"], &["-HV", "2021"])
+        .expect("link call");
+
+    let OperationOutput { messages, blob } =
+        OperationOutput::from_operation_result(result).expect("link success");
+    if let Some(m) = messages {
+        eprintln!("link messages:\n{m}");
+    }
+
+    let bytes: &[u8] = blob.as_ref();
+    println!("linked DXIL: {} bytes", bytes.len());
+    assert!(!bytes.is_empty(), "linker produced an empty blob");
+    // DXIL containers start with "DXBC" magic.
+    assert_eq!(&bytes[..4], b"DXBC", "expected DXBC magic at start of blob");
+    println!("DXBC magic present — linker output looks valid");
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -505,6 +505,85 @@ impl DxcCompiler {
     }
 }
 
+/// Links pre-compiled HLSL library blobs (produced by compiling with a
+/// `lib_6_x` profile) into a final shader binary with a chosen entry point
+/// and target profile.
+///
+/// Typical use:
+///
+/// 1. Compile each shader source to a library blob via [`DxcCompiler::compile`]
+///    using a `lib_6_x` target profile.
+/// 2. Register every library blob with [`Self::register_library`] under a
+///    unique name.
+/// 3. Call [`Self::link`] with the names of the libraries to combine, the
+///    entry-point function name, and a non-library target profile such as
+///    `cs_6_8`.
+pub struct DxcLinker {
+    inner: IDxcLinker,
+}
+
+impl DxcLinker {
+    fn new(inner: IDxcLinker) -> Self {
+        Self { inner }
+    }
+
+    /// Registers a library blob with this linker under `lib_name`.
+    ///
+    /// The same name is then referenced in the `lib_names` argument of
+    /// [`Self::link`]. The linker holds an internal reference to the blob; the
+    /// caller does not need to keep `blob` alive past this call.
+    pub fn register_library(&self, lib_name: &str, blob: &DxcBlob) -> Result<()> {
+        let wide_name = to_wide(lib_name);
+        unsafe {
+            self.inner
+                .register_library(wide_name.as_ptr(), blob.inner.clone())
+        }
+        .result()
+    }
+
+    /// Links previously-registered libraries into a final shader binary.
+    ///
+    /// `entry_point` is the name of the function (exported by one of the
+    /// registered libraries) that will become the entry point of the linked
+    /// shader. `target_profile` is a non-library profile such as `cs_6_8`.
+    /// `lib_names` is the list of library names previously passed to
+    /// [`Self::register_library`] that should be included in the link.
+    /// `args` is forwarded to DXC like the args of [`DxcCompiler::compile`].
+    pub fn link(
+        &self,
+        entry_point: &str,
+        target_profile: &str,
+        lib_names: &[&str],
+        args: &[&str],
+    ) -> Result<DxcOperationResult, HassleError> {
+        let wide_entry = to_wide(entry_point);
+        let wide_profile = to_wide(target_profile);
+
+        let wide_lib_names: Vec<Vec<WCHAR>> = lib_names.iter().map(|n| to_wide(n)).collect();
+        let lib_name_ptrs: Vec<LPCWSTR> = wide_lib_names.iter().map(|n| n.as_ptr()).collect();
+
+        let wide_args: Vec<Vec<WCHAR>> = args.iter().map(|a| to_wide(a)).collect();
+        let arg_ptrs: Vec<LPCWSTR> = wide_args.iter().map(|a| a.as_ptr()).collect();
+
+        let mut result = None;
+        unsafe {
+            self.inner.link(
+                wide_entry.as_ptr(),
+                wide_profile.as_ptr(),
+                lib_name_ptrs.as_ptr(),
+                lib_name_ptrs.len() as u32,
+                arg_ptrs.as_ptr(),
+                arg_ptrs.len() as u32,
+                &mut result,
+            )
+        }
+        .result()?;
+
+        let result = result.expect("Non-null IDxcOperationResult");
+        Ok(DxcOperationResult::new(result))
+    }
+}
+
 #[derive(Clone)]
 pub struct DxcLibrary {
     inner: IDxcLibrary,
@@ -600,6 +679,13 @@ impl Dxc {
         self.get_dxc_create_instance()?(&CLSID_DxcLibrary, &IDxcLibrary::IID, &mut library)
             .result()?;
         Ok(DxcLibrary::new(library.unwrap()))
+    }
+
+    pub fn create_linker(&self) -> Result<DxcLinker> {
+        let mut linker = None;
+        self.get_dxc_create_instance()?(&CLSID_DxcLinker, &IDxcLinker::IID, &mut linker)
+            .result()?;
+        Ok(DxcLinker::new(linker.unwrap()))
     }
 
     pub fn create_reflector(&self) -> Result<DxcReflector> {


### PR DESCRIPTION
## Summary

- Adds a public `DxcLinker` wrapper in `src/wrapper.rs`, mirroring the existing `DxcCompiler` / `DxcLibrary` patterns and exposing `IDxcLinker::register_library` and `IDxcLinker::link`.
- Adds `Dxc::create_linker()` as the factory.
- Adds `examples/link.rs` (plus two small HLSL files) demonstrating the full flow: compile two sources to `lib_6_8` DXIL, register, link to `cs_6_8`, assert the result starts with the `DXBC` magic.

The `IDxcLinker` FFI declaration and `CLSID_DxcLinker` were already present in `src/ffi.rs`; this PR only adds the safe Rust API on top.

## Motivation

Lets callers build shader permutations by linking pre-compiled function libraries instead of recompiling HLSL text on every change — useful for material systems, ubershader caches, and similar shader-graph use cases.

## Test plan

- [x] `cargo run --example link` produces a non-empty DXIL blob starting with the `DXBC` magic on macOS (verified locally with `libdxcompiler.dylib` from a recent DXC build).
- [ ] CI builds the example on all supported platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)