### PR TITLE
fix: avoid div-by-zero in as_slice / as_mut_slice

### DIFF
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -40,15 +40,11 @@ impl DxcBlob {
 
     pub fn as_slice<T>(&self) -> &[T] {
         let bytes = unsafe { self.inner.get_buffer_size() };
-        if bytes == 0 {
+        if bytes == 0 || std::mem::size_of::<T>() == 0 {
             &[]
         } else {
             unsafe {
-                let len = if size_of::<T>() == 0 {
-                    0
-                } else {
-                    bytes / size_of::<T>()
-                };
+                let len = bytes / std::mem::size_of::<T>();
                 std::slice::from_raw_parts(self.inner.get_buffer_pointer().cast(), len)
             }
         }
@@ -56,15 +52,11 @@ impl DxcBlob {
 
     pub fn as_mut_slice<T>(&mut self) -> &mut [T] {
         let bytes = unsafe { self.inner.get_buffer_size() };
-        if bytes == 0 {
+        if bytes == 0 || std::mem::size_of::<T>() == 0 {
             &mut []
         } else {
             unsafe {
-                let len = if size_of::<T>() == 0 {
-                    0
-                } else {
-                    bytes / size_of::<T>()
-                };
+                let len = bytes / std::mem::size_of::<T>();
                 std::slice::from_raw_parts_mut(self.inner.get_buffer_pointer().cast(), len)
             }
         }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -44,10 +44,12 @@ impl DxcBlob {
             &[]
         } else {
             unsafe {
-                std::slice::from_raw_parts(
-                    self.inner.get_buffer_pointer().cast(),
-                    bytes / size_of::<T>(),
-                )
+                let len = if size_of::<T>() == 0 {
+                    0
+                } else {
+                    bytes / size_of::<T>()
+                };
+                std::slice::from_raw_parts(self.inner.get_buffer_pointer().cast(), len)
             }
         }
     }
@@ -58,10 +60,12 @@ impl DxcBlob {
             &mut []
         } else {
             unsafe {
-                std::slice::from_raw_parts_mut(
-                    self.inner.get_buffer_pointer().cast(),
-                    bytes / size_of::<T>(),
-                )
+                let len = if size_of::<T>() == 0 {
+                    0
+                } else {
+                    bytes / size_of::<T>()
+                };
+                std::slice::from_raw_parts_mut(self.inner.get_buffer_pointer().cast(), len)
             }
         }
     }


### PR DESCRIPTION
Add checks to avoid div-by-zero.

Fixes: #103 