### PR TITLE
wrapper: Drop generic `T` from `DxcBlob::as(_mut)_slice` in favour of `&[u8]`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -142,7 +142,7 @@ impl OperationOutput {
                 } else {
                     Some(error.to_owned())
                 },
-                blob: output.to_vec(),
+                blob: output.as_slice().to_vec(),
             })
         }
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -38,36 +38,22 @@ impl DxcBlob {
         Self { inner }
     }
 
-    pub fn as_slice<T>(&self) -> &[T] {
-        let bytes = unsafe { self.inner.get_buffer_size() };
-        if bytes == 0 {
+    pub fn as_slice(&self) -> &[u8] {
+        let len = unsafe { self.inner.get_buffer_size() };
+        if len == 0 {
             &[]
         } else {
-            unsafe {
-                std::slice::from_raw_parts(
-                    self.inner.get_buffer_pointer().cast(),
-                    bytes / size_of::<T>(),
-                )
-            }
+            unsafe { std::slice::from_raw_parts(self.inner.get_buffer_pointer().cast(), len) }
         }
     }
 
-    pub fn as_mut_slice<T>(&mut self) -> &mut [T] {
-        let bytes = unsafe { self.inner.get_buffer_size() };
-        if bytes == 0 {
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        let len = unsafe { self.inner.get_buffer_size() };
+        if len == 0 {
             &mut []
         } else {
-            unsafe {
-                std::slice::from_raw_parts_mut(
-                    self.inner.get_buffer_pointer().cast(),
-                    bytes / size_of::<T>(),
-                )
-            }
+            unsafe { std::slice::from_raw_parts_mut(self.inner.get_buffer_pointer().cast(), len) }
         }
-    }
-
-    pub fn to_vec<T: Clone>(&self) -> Vec<T> {
-        self.as_slice().to_vec()
     }
 }
 


### PR DESCRIPTION
A `DxcBlob` is usually consumed as an arbitrary byte buffer or a UTF-8 string, so the generic `T` getters offered little real utility.  Worse, they did not validate alignment of the underlying buffer for `T`, nor that the buffer size was a multiple of `size_of::<T>()` (trailing bytes were silently truncated), and panicked on division by zero when `T` was a zero-sized type.  Expose the buffer as `&[u8]`/`&mut [u8]` and let callers reinterpret if they need to.

The now-redundant `to_vec<T: Clone>` helper is removed; its sole caller in `OperationOutput::from_operation_result()` switches to `as_slice().to_vec()`.

Closes: #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)